### PR TITLE
Variant calling fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # changelog
 
 ## 0.9.0
- - fixed many smaller issues.
+ - Fixed many smaller issues.
  - Added integration with EPI2ME Labs.
+ - Changed consensus insert filtering rule to pass reads with YM >= 3 instead of YM > 3.
+ - Fixed filtered consensus insert number propagation to report. Workflow now outputs BAM with consensus inserts after filtering.
 
 ## 0.8.2
 - Fixed issue where variant filtering throwed an error when variant dataframe becomes empty before DPQ filtering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
  - Added integration with EPI2ME Labs.
  - Changed consensus insert filtering rule to pass reads with YM >= 3 instead of YM > 3.
  - Fixed filtered consensus insert number propagation to report. Workflow now outputs BAM with consensus inserts after filtering.
+ - Fixed VCF position reporting when depth at position is 0
+ - Fixed non-contiguous chromosome error by adding back -a flag to bcftools sort
+ - Changed AnntotateBamXTags label
 
 ## 0.8.2
 - Fixed issue where variant filtering throwed an error when variant dataframe becomes empty before DPQ filtering.

--- a/bin/detect_indel.py
+++ b/bin/detect_indel.py
@@ -235,7 +235,7 @@ def extract_indel_evidence(
         and a VCF_entry object with variant information.
     """
 
-    vcf_entry = VCF_entry(None)
+    vcf_entry = VCF_entry()
     alleles = (".", ".")
 
     if not end_of_amplicon:

--- a/bin/detect_snp.py
+++ b/bin/detect_snp.py
@@ -32,8 +32,8 @@ def extract_snp_evidence(
         and a VCF_entry object with variant information.
     """
 
-    vcf_entry = VCF_entry(None)
-    alleles = (".", ".")
+    vcf_entry = VCF_entry()
+    alleles = (ref_nt, ".")
 
     total = 0
     counted_nucs = 0
@@ -323,13 +323,13 @@ if __name__ == "__main__":
     if dev:
         # PNK_01
         fasta = Path(
-            "/scratch/nxf_work/rodrigo/09/c1f67a8cf5b2a8783a8a1981295eb9/chm13v2_BB42.fasta"
+            "/scratch/nxf_work/rodrigo/fe/531d9c9f51cadbc31e59f657fdd523/GCA_000001405_BB42.fasta"
         )
         bed = Path(
-            "/scratch/nxf_work/rodrigo/09/c1f67a8cf5b2a8783a8a1981295eb9/FAW03991_roi.bed"
+            "/scratch/nxf_work/rodrigo/fe/531d9c9f51cadbc31e59f657fdd523/FAV97214_roi.bed"
         )
         bam = Path(
-            "/scratch/nxf_work/rodrigo/09/c1f67a8cf5b2a8783a8a1981295eb9/FAW03991.YM_gt_3.bam"
+            "/scratch/nxf_work/rodrigo/fe/531d9c9f51cadbc31e59f657fdd523/FAV97214.YM_gt_3.bam"
         )
         vcf_out = Path("./test2_snp.vcf")
 

--- a/bin/detect_snp.py
+++ b/bin/detect_snp.py
@@ -118,7 +118,6 @@ def extract_snp_evidence(
     else:
         quals_mean = 0
 
-
     nucs = nucs_fwd + nucs_rev
     counts_fwd, counts_rev, counts = (
         Counter(nucs_fwd),
@@ -162,7 +161,7 @@ def extract_snp_evidence(
             alt_base = counts_alt[0][0]
             alleles = (ref_nt, alt_base)
 
-            alt_base_qualities= [x[1] for x in nuc_qual if x[0] == alt_base]
+            alt_base_qualities = [x[1] for x in nuc_qual if x[0] == alt_base]
             # We cannot calculate the mean of an empty array.
             if len(alt_base_qualities) > 0:
                 alt_base_mean_qual = np.mean(alt_base_qualities)
@@ -172,7 +171,11 @@ def extract_snp_evidence(
             # calculate
             ticker = [x[1] for x in ym_ticker if x[0] == ref_nt]
             alt_ticker = [x[1] for x in ym_ticker if x[0] == alt_base]
-            obs_ratio = 1 / (sum(ticker) + sum(alt_ticker)) * sum(alt_ticker)
+
+            if sum(alt_ticker) != 0:
+                obs_ratio = 1 / (sum(ticker) + sum(alt_ticker)) * sum(alt_ticker)
+            else:
+                obs_ratio = 0
 
         # Check support fwd
         if len(counts_fwd_mc) > 1:
@@ -320,13 +323,13 @@ if __name__ == "__main__":
     if dev:
         # PNK_01
         fasta = Path(
-            "/scratch/nxf_work/dami/b6/b1293bac824269db94893b246f0829/GCA_000001405_BB42.fasta"
+            "/scratch/nxf_work/rodrigo/09/c1f67a8cf5b2a8783a8a1981295eb9/chm13v2_BB42.fasta"
         )
         bed = Path(
-            "/scratch/nxf_work/dami/b6/b1293bac824269db94893b246f0829/FAV97214_roi.bed"
+            "/scratch/nxf_work/rodrigo/09/c1f67a8cf5b2a8783a8a1981295eb9/FAW03991_roi.bed"
         )
         bam = Path(
-            "/data/sequencing/results/Cyclomics/0.9.0-rc13/000123/consensus_aligned/FAV97298.YM_gt_3.bam"
+            "/scratch/nxf_work/rodrigo/09/c1f67a8cf5b2a8783a8a1981295eb9/FAW03991.YM_gt_3.bam"
         )
         vcf_out = Path("./test2_snp.vcf")
 

--- a/bin/detect_snp.py
+++ b/bin/detect_snp.py
@@ -109,8 +109,15 @@ def extract_snp_evidence(
     else:
         hc_ratio = 0
 
-    total = pileupcolumn.n
-    quals_mean = np.mean(quals)
+    # if the depth is 0, make total an integer and not None
+    total = pileupcolumn.n if pileupcolumn.n is not None else 0
+
+    # We cannot calculate the mean of an empty array.
+    if len(quals) > 0:
+        quals_mean = np.mean(quals)
+    else:
+        quals_mean = 0
+
 
     nucs = nucs_fwd + nucs_rev
     counts_fwd, counts_rev, counts = (
@@ -152,9 +159,16 @@ def extract_snp_evidence(
             # alleles = [x[0] for x in counts_mc]
             counts_alt = [t for t in counts_mc if t[0] != ref_nt]
 
-            alleles = (ref_nt, counts_alt[0][0])
             alt_base = counts_alt[0][0]
-            alt_base_mean_qual = np.mean([x[1] for x in nuc_qual if x[0] == alt_base])
+            alleles = (ref_nt, alt_base)
+
+            alt_base_qualities= [x[1] for x in nuc_qual if x[0] == alt_base]
+            # We cannot calculate the mean of an empty array.
+            if len(alt_base_qualities) > 0:
+                alt_base_mean_qual = np.mean(alt_base_qualities)
+            else:
+                alt_base_mean_qual = 0
+
             # calculate
             ticker = [x[1] for x in ym_ticker if x[0] == ref_nt]
             alt_ticker = [x[1] for x in ym_ticker if x[0] == alt_base]
@@ -189,6 +203,7 @@ def extract_snp_evidence(
             base = alt_base_fwd
 
         tot_count = fwd_count + rev_count
+        # No need to escape this mean due to never beeing empty
         tot_ratio = np.mean((alt_base_ratio_fwd, alt_base_ratio_rev))
 
         vcf_entry.DP = total

--- a/bin/determine_vaf.py
+++ b/bin/determine_vaf.py
@@ -35,8 +35,15 @@ def process_pileup_column(
     logging.debug(f"process column {contig} | {pos}")
     bam_af = pysam.AlignmentFile(bam, "r")
     reference = pysam.FastaFile(reference_fasta)
-    ref_nuc = str(reference.fetch(reference=contig, start=pos, end=pos + 1)).upper()
-
+    print(reference.references)
+    try:
+        ref_nuc = str(reference.fetch(reference=contig, start=pos, end=pos + 1)).upper()
+    except KeyError:
+        try:
+            ref_nuc = str(reference.fetch(reference=contig, start=pos, end=pos + 1)).upper()
+        except KeyError:
+            ref_nuc = "."
+        
     iteration = 0
     # create enteties for when no forloop event happens
     snv_evidence = None

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest{
     description = 'Create high quality alignment data with variant identification for the Cyclomics CyclomicsSeq protocol.'
     mainScript      = 'main.nf'
     nextflowVersion = '>=20.10.0'
-    version         = '0.9.0-rc13'
+    version         = '0.9.0-rc14'
 }
 
 epi2melabs {

--- a/nextflow.config
+++ b/nextflow.config
@@ -118,6 +118,10 @@ process{
 }
 
 params{
+  roi_detection{
+    min_depth = 100
+    max_distance= 25
+  }
   out_dir = "output"
   filtering{
     minimun_raw_length  = 1000

--- a/subworkflows/align.nf
+++ b/subworkflows/align.nf
@@ -166,15 +166,24 @@ workflow Minimap2Align{
         bam = SamtoolsMergeBams.out
 }
 
-workflow AnnotateFilter{
+workflow AnnotateBam{
     take:
         reads
         sequencing_summary
-        minimun_repeat_count
 
     main:
         AnnotateBamXTags(reads, sequencing_summary)
-        BamTagFilter(AnnotateBamXTags.out, 'YM', minimun_repeat_count)
+    emit:
+        AnnotateBamXTags.out
+}
+
+workflow FilterBam{
+    take:
+        annotated_bam
+        minimun_repeat_count
+
+    main:
+        BamTagFilter(annotated_bam, 'YM', minimun_repeat_count)
     emit:
         BamTagFilter.out
 }

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -215,7 +215,7 @@ process PlotFastqsQUalAndLength{
 process PlotReadStructure{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
     publishDir "${params.output_dir}/QC", mode: 'copy'
-    label 'many_low_cpu_high_mem'
+    label 'many_low_cpu_huge_mem'
 
     input:
         tuple val(X), path(bam), path(bai)
@@ -285,7 +285,7 @@ process PlotQScores{
 process PlotMetadataStats{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
     publishDir "${params.output_dir}/QC", mode: 'copy'
-    label 'many_low_cpu_high_mem'
+    label 'many_low_cpu_huge_mem'
 
     input:
         path(jsons)

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -20,7 +20,7 @@ process AddDepthToJson{
 
 process AnnotateBamXTags{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
-    publishDir "${params.output_dir}/consensus_aligned_tagged", mode: 'copy'
+    // publishDir "${params.output_dir}/consensus_aligned_tagged", mode: 'copy'
     label 'many_low_cpu_high_mem'
 
     input:
@@ -28,11 +28,11 @@ process AnnotateBamXTags{
         path(sequencing_summary)
 
     output:
-        tuple val(X), path("${X}.taged.bam"), path("${X}.taged.bam.bai")
+        tuple val(X), path("${X}.tagged.bam"), path("${X}.tagged.bam.bai")
 
     script:
         """
-        annotate_bam_x.py $sequencing_summary $bam ${X}.taged.bam
+        annotate_bam_x.py $sequencing_summary $bam ${X}.tagged.bam
         """
 }
 

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -21,7 +21,7 @@ process AddDepthToJson{
 process AnnotateBamXTags{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
     // publishDir "${params.output_dir}/consensus_aligned_tagged", mode: 'copy'
-    label 'many_low_cpu_high_mem'
+    label 'few_very_memory_intensive'
 
     input:
         tuple val(X), path(bam), path(bai)
@@ -146,7 +146,7 @@ process MergeNoisyVCF{
         bgzip ${noisy_indel_vcf.simpleName}.sorted.indel.vcf
         tabix ${noisy_indel_vcf.simpleName}.sorted.indel.vcf.gz
 
-        bcftools concat ${noisy_snp_vcf.simpleName}.sorted.snp.vcf.gz ${noisy_indel_vcf.simpleName}.sorted.indel.vcf.gz \
+        bcftools concat -a ${noisy_snp_vcf.simpleName}.sorted.snp.vcf.gz ${noisy_indel_vcf.simpleName}.sorted.indel.vcf.gz \
         -O v -o ${noisy_snp_vcf.simpleName}.noisy_merged.tmp.vcf
         bcftools sort ${noisy_snp_vcf.simpleName}.noisy_merged.tmp.vcf -o ${noisy_snp_vcf.simpleName}.noisy_merged.vcf
         rm ${noisy_snp_vcf.simpleName}.noisy_merged.tmp.vcf
@@ -173,7 +173,7 @@ process MergeFilteredVCF{
         bgzip ${filtered_indel_vcf.simpleName}.sorted.indel.vcf
         tabix ${filtered_indel_vcf.simpleName}.sorted.indel.vcf.gz
 
-        bcftools concat ${filtered_snp_vcf.simpleName}.sorted.snp.vcf.gz ${filtered_indel_vcf.simpleName}.sorted.indel.vcf.gz \
+        bcftools concat -a ${filtered_snp_vcf.simpleName}.sorted.snp.vcf.gz ${filtered_indel_vcf.simpleName}.sorted.indel.vcf.gz \
         -O v -o ${filtered_snp_vcf.simpleName}.filtered_merged.tmp.vcf
         bcftools sort ${filtered_snp_vcf.simpleName}.filtered_merged.tmp.vcf -o ${filtered_snp_vcf.simpleName}.filtered_merged.vcf
         rm ${filtered_snp_vcf.simpleName}.filtered_merged.tmp.vcf

--- a/subworkflows/modules/samtools.nf
+++ b/subworkflows/modules/samtools.nf
@@ -343,6 +343,7 @@ process MPileup{
 
 process BamTagFilter{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
+    publishDir "${params.output_dir}/consensus_aligned", mode: 'copy'
     label 'many_cpu_medium'
     
     input:
@@ -355,7 +356,7 @@ process BamTagFilter{
 
     script:
         """
-        samtools view -b -o ${X}.${tag}_gt_${minimum_repeats}.bam $bam_in --input-fmt-option 'filter=[${tag}]>${minimum_repeats}'
+        samtools view -b -o ${X}.${tag}_gt_${minimum_repeats}.bam $bam_in --input-fmt-option 'filter=[${tag}]>=${minimum_repeats}'
         samtools index ${X}.${tag}_gt_${minimum_repeats}.bam
         """
 }

--- a/subworkflows/modules/samtools.nf
+++ b/subworkflows/modules/samtools.nf
@@ -318,8 +318,9 @@ process FindRegionOfInterest{
         tuple val(X), path("${X}_roi.bed")
 
     script:
+        // 
         """
-        samtools depth $bam_in | awk '\$3>100' | awk '{print \$1"\t"\$2"\t"\$2 + 1}' | bedtools merge -d 25 -i /dev/stdin > ${X}_roi.bed
+        samtools depth $bam_in | awk '\$3>${params.roi_detection.min_depth}' | awk '{print \$1"\t"\$2"\t"\$2 + 1}' | bedtools merge -d ${params.roi_detection.max_distance} -i /dev/stdin > ${X}_roi.bed
         """
 }
 


### PR DESCRIPTION
 - Fixed VCF position reporting when depth at position is 0
Sometimes detected regions of interest have positions where depth is 0, where no reads are mapping (presumably because roi are merged if they are very close to each other). In this case, a superfluous "None" in `VCF_entry` initialization was causing the total depth (DP) value to be turned to "None" instead of 0.

 - Fixed non-contiguous chromosome error by adding back -a flag to bcftools sort
 Despite our previous suspicions that `-a` may be causing some empty output VCF files when trying to merge a VCF with variants and a VCF with no variants, with recent tests we found that it will break chromosome contiguity if e.g. an indel is found in the middle of the list of SNPs. We tested again with empty VCF files, and it seems to behave properly.
 
 - Changed AnntotateBamXTags label
 Changed label to `few_very_memory_intensive` to be able to set the amount of requested RAM.