### PR TITLE
Metadata plotting resource usage improvements

### DIFF
--- a/bin/plot_metadata.py
+++ b/bin/plot_metadata.py
@@ -269,8 +269,9 @@ def parse_Cycas_metadata(
 def read_jsons_into_plots(
     json_folder,
     plot_file,
-    subsample: bool = True,
+    subsample_files: bool = False,
     file_subset_size: int = 200,
+    subsample_reads: bool = True,
     read_subset_size: int = 10_000,
     seed: int = 42,
     threads: int = 16,
@@ -282,8 +283,9 @@ def read_jsons_into_plots(
     with ProcessPoolExecutor(max_workers=threads) as executor:
         logging.debug("creating location promisses in ProcessPoolExecutor")
         json_files = glob.glob(f"{json_folder}/*.json")
-        # if subsample:
-        #     json_files = rng.choice(json_files, file_subset_size)
+        if subsample_files:
+            json_files = rng.choice(json_files, file_subset_size)
+
         for test_json in json_files:
             with open(str(test_json)) as d:
                 dict_data_json = json.load(d)
@@ -332,7 +334,7 @@ def read_jsons_into_plots(
     n_reads = len(raw_lens)
     if n_reads > read_subset_size:
         idx = rng.choice(np.arange(n_reads), read_subset_size)
-        if subsample:
+        if subsample_reads:
             raw_lens = raw_lens[idx]
             aln_lens = aln_lens[idx]
             segments = segments[idx]
@@ -385,14 +387,15 @@ if __name__ == "__main__":
 
     tracemalloc.start()
 
-    dev = True
+    dev = False
 
     if dev:
         read_jsons_into_plots(
             "/data/projects/ROD_1002_cycseq-093/plot_metadata/jsons/",
             "./metadata.html",
-            subsample=True,
+            subsample_files=False,
             file_subset_size=200,
+            subsample_reads=True,
             read_subset_size=10_000,
             seed=42,
             threads=16,
@@ -405,6 +408,12 @@ if __name__ == "__main__":
 
         parser.add_argument("json_glob_path")
         parser.add_argument("plot_file")
+        parser.add_argument("--subsample_files", default=True)
+        parser.add_argument("--file_subset_size", default=200)
+        parser.add_argument("--subsample_reads", default=True)
+        parser.add_argument("--read_subset_size", default=10_000)
+        parser.add_argument("--seed", default=42)
+        parser.add_argument("--threads", default=16)
         args = parser.parse_args()
 
         read_jsons_into_plots(args.json_glob_path, args.plot_file)

--- a/bin/plot_metadata.py
+++ b/bin/plot_metadata.py
@@ -7,7 +7,6 @@ import random
 from collections import Counter
 from math import pi
 from pathlib import Path
-import tracemalloc
 
 import numpy as np
 import pandas as pd
@@ -56,7 +55,7 @@ cycas_class_mapper = {
 
 
 def _calculate_angle_and_color(stats, concat_type_colors):
-    print(stats)
+    # print(stats)
     _df1 = pd.DataFrame.from_dict(stats, orient="index").reset_index()
     _df1.columns = ["type", "count"]
     _df1["angle"] = _df1["count"] / _df1["count"].sum() * 2 * pi
@@ -385,7 +384,9 @@ def read_jsons_into_plots(
 if __name__ == "__main__":
     import argparse
 
-    tracemalloc.start()
+    # import tracemalloc
+
+    # tracemalloc.start()
 
     dev = False
 
@@ -408,7 +409,7 @@ if __name__ == "__main__":
 
         parser.add_argument("json_glob_path")
         parser.add_argument("plot_file")
-        parser.add_argument("--subsample_files", default=True)
+        parser.add_argument("--subsample_files", default=False)
         parser.add_argument("--file_subset_size", default=200)
         parser.add_argument("--subsample_reads", default=True)
         parser.add_argument("--read_subset_size", default=10_000)
@@ -416,12 +417,20 @@ if __name__ == "__main__":
         parser.add_argument("--threads", default=16)
         args = parser.parse_args()
 
-        read_jsons_into_plots(args.json_glob_path, args.plot_file)
-    # read_jsons_into_plots('dummy_json', 'tmp.html')
+        read_jsons_into_plots(
+            args.json_glob_path,
+            args.plot_file,
+            args.subsample_files,
+            int(args.file_subset_size),
+            args.subsample_reads,
+            int(args.read_subset_size),
+            int(args.seed),
+            int(args.threads),
+        )
 
-    snapshot = tracemalloc.take_snapshot()
-    top_stats = snapshot.statistics("lineno")
+    # snapshot = tracemalloc.take_snapshot()
+    # top_stats = snapshot.statistics("lineno")
 
-    print("[ Top 10 ]")
-    for stat in top_stats[:10]:
-        print(stat)
+    # print("[ Top 10 ]")
+    # for stat in top_stats[:10]:
+    # print(stat)

--- a/nextflow.config
+++ b/nextflow.config
@@ -181,11 +181,7 @@ params{
     batch_size = 1000
   }
   metadata{
-    subsample_files = 'False'
-    file_subset_size = 200
-    subsample_reads = 'True'
-    read_subset_size = 10_000
-    seed = 42
+    subsample_size = 10_000
   }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -180,6 +180,13 @@ params{
     length = 50
     batch_size = 1000
   }
+  metadata{
+    subsample_files = False
+    file_subset_size = 200
+    subsample_reads = True
+    read_subset_size = 10_000
+    seed = 42
+  }
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -181,9 +181,9 @@ params{
     batch_size = 1000
   }
   metadata{
-    subsample_files = False
+    subsample_files = 'False'
     file_subset_size = 200
-    subsample_reads = True
+    subsample_reads = 'True'
     read_subset_size = 10_000
     seed = 42
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -185,14 +185,14 @@ params{
 
 timeline {
   enabled = true
-  file = "${params.out_dir}/execution/timeline.html"
+  file = "${params.output_dir}/execution/timeline.html"
 }
 report {
   enabled = true
-  file = "${params.out_dir}/execution/report.html"
+  file = "${params.output_dir}/execution/report.html"
 }
 trace {
   enabled = true
   overwrite = true
-  file = "${params.out_dir}/execution/trace.txt"
+  file = "${params.output_dir}/execution/trace.txt"
 }

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -307,7 +307,7 @@ process PlotQScores{
 process PlotMetadataStats{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
     publishDir "${params.output_dir}/QC", mode: 'copy'
-    label 'few_memory_intensive'
+    label 'many_low_cpu_huge_mem'
     memory { task.memory * task.attempt }
     errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
     maxRetries 3
@@ -319,15 +319,8 @@ process PlotMetadataStats{
         tuple path("metadata_plots.html"), path("metadata_plots.json")
     
     script:
-        // This takes a lot of RAM when the sequencing summary is big!
         """
-        plot_metadata.py . metadata_plots.html \
-        --subsample_files $params.metadata.subsample_files \
-        --file_subset_size $params.metadata.file_subset_size \
-        --subsample_reads $params.metadata.subsample_reads \
-        --read_subset_size $params.metadata.read_subset_size \
-        --seed $params.metadata.seed \
-        --threads ${task.cpus}
+        plot_metadata.py . metadata_plots.html --subsample_size $params.metadata.subsample_size
         """
 }
 

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -307,7 +307,7 @@ process PlotQScores{
 process PlotMetadataStats{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
     publishDir "${params.output_dir}/QC", mode: 'copy'
-    label 'many_low_cpu_huge_mem'
+    label 'few_memory_intensive'
     memory { task.memory * task.attempt }
     errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
     maxRetries 3
@@ -321,7 +321,13 @@ process PlotMetadataStats{
     script:
         // This takes a lot of RAM when the sequencing summary is big!
         """
-        plot_metadata.py . metadata_plots.html
+        plot_metadata.py . metadata_plots.html \
+        --subsample_files $params.metadata.subsample_files \
+        --file_subset_size $params.metadata.file_subset_size \
+        --subsample_reads $params.metadata.subsample_reads \
+        --read_subset_size $params.metadata.read_subset_size \
+        --seed $params.metadata.seed \
+        --threads ${task.cpus}
         """
 }
 


### PR DESCRIPTION
- Obtained data from metadata JSON files were minimized
- Data structures were changed to numpy arrays
- Metadata is per default subsampled to 10,000 reads, after which input JSON files are not read anymore. This value is user-settable with the `--metadata.subsample_size <INT>` flag. if `<INT>` is set to `0`, then all reads are taken into account for plotting, essentially inactivating the subsampling feature.
- The output directory for the nxf trace report was changed to the be created within the pipeline output directory.