### PR TITLE
Bug/plot data parsing

### DIFF
--- a/bin/catch_plotting_errors.sh
+++ b/bin/catch_plotting_errors.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+if [ -s $1 ]; then
+    echo "Caught a plotting error"
+
+    NAME="Consensus quality"
+    PRIORITY=91
+    ERROR=`(cat $1)`
+    PAGE_CONTENTS="<h1>Plotting for $NAME failed</h1><b>ERROR MESSAGE</b><br><p style="font-family:monospace"><FONT color="#DC381F">$ERROR</FONT></p>"
+    STATUS=1
+
+    JSON_FMT='{"%s": {"name":"%s","priority":%s,"script":"%s","div":"%s"},"additional_info": {"exit_status":%s}}\n'
+    printf "$JSON_FMT" "$NAME" "$NAME" "$PRIORITY" "$PAGE_CONTENTS" "$PAGE_CONTENTS" "$STATUS" > $2
+
+else
+    echo "No plotting errors"
+fi

--- a/bin/generate_report.py
+++ b/bin/generate_report.py
@@ -156,34 +156,34 @@ def main(args):
             "Sequencing reads",
             "fa-dna",
             "readsRaw fastq info",
-            "text-succes",
+            "text-dark",
         ),  # count from input material
         (
             "Post split & QC reads",
             "fa-filter",
             "readsFiltered fastq info",
-            "text-succes",
+            "text-dark",
         ),
         (
             "Aligning reads",
             "fa-align-center",
             "Reference_aligned_with_backbone",
-            "text-succes",
+            "text-dark",
         ),  # reads aligning in initial alignment
         (
             "Consensus inserts",
             "fa-bars",
             "total_reference_mapping_reads",
-            "text-succes",
+            "text-dark",
         ),
         (
             "Variants found",
             "fa-map-marker-alt",
             "variants_found_non_backbone",
-            "text-succes",
+            "text-dark",
         ),
-        ("Backbone-insert %", "fa-bullseye", "read_struc_prec_bbi", "text-succes"),
-        ("Pipeline version", "fa-code-branch", "git_version", "text-succes"),
+        ("Backbone-insert %", "fa-bullseye", "read_struc_prec_bbi", "text-dark"),
+        ("Pipeline version", "fa-code-branch", "git_version", "text-dark"),
     ]:
         try:
             data["cards"].append(
@@ -191,6 +191,17 @@ def main(args):
             )
         except KeyError:
             data["cards"].append(SummaryCard(i[0], i[1], "nan", i[3]))
+
+    if ("exit_status", 1) in data["additional_info"].items():
+        data["cards"].append(
+            SummaryCard(
+                "Plotting error",
+                "fas fa-times-circle",
+                "Warning!",
+                "text-warning",
+            )
+        )
+
     print(data["additional_info"])
     # print(tabs)
     with open(REPORT, "w") as fh:

--- a/bin/generate_report.py
+++ b/bin/generate_report.py
@@ -15,7 +15,12 @@ from bokeh.embed import components
 from bokeh.models.widgets import Panel, Tabs
 from bokeh.models import Div
 
-from plotting_defaults import cyclomics_defaults, TEMPLATE_STR, nextflow_params_parser, human_format
+from plotting_defaults import (
+    cyclomics_defaults,
+    TEMPLATE_STR,
+    nextflow_params_parser,
+    human_format,
+)
 
 REPORT = "report.html"
 
@@ -95,19 +100,24 @@ class ReportTabCollection:
         return [x.script for x in self.tabs]
 
     def generate_tabs(self, overall_width=cyclomics_defaults.width, priority_limit=89):
-        self.tabs.sort(key=lambda x : x.priority)
+        self.tabs.sort(key=lambda x: x.priority)
 
         pre_tabs = []
         for i, tab in enumerate(self.tabs, start=1):
             plot = tab.plot
             # we set the width here and it propogates to the overall width of the tab selector
             # https://github.com/bokeh/bokeh/issues/8726
-            pre_tabs.append((
-                Panel(child=Div(text=plot, width=overall_width), title=f"{i}. {tab.name}"),
-                tab.priority
-            ))
+            pre_tabs.append(
+                (
+                    Panel(
+                        child=Div(text=plot, width=overall_width),
+                        title=f"{i}. {tab.name}",
+                    ),
+                    tab.priority,
+                )
+            )
 
-        pre_tabs.sort(key = lambda x: x[1] )
+        pre_tabs.sort(key=lambda x: x[1])
         pre_tabs = [x[0] for x in pre_tabs if x[1] < priority_limit]
 
         return components(Tabs(tabs=pre_tabs))
@@ -196,7 +206,7 @@ if __name__ == "__main__":
 
     parser.add_argument("nextflow_params", type=str)
     parser.add_argument("version", type=str)
-    parser.add_argument("priority_limit",type=int, default= 89)
+    parser.add_argument("priority_limit", type=int, default=89)
 
     args = parser.parse_args()
     print(args)

--- a/bin/plot_bam_accuracy.py
+++ b/bin/plot_bam_accuracy.py
@@ -23,7 +23,6 @@ SIDE_DIST_PLOT_SIZE = 100
 TAB_PRIORITY = 91
 
 
-
 def get_roi_pileup_df(
     df: pd.DataFrame, distance: int = 100
 ) -> List[chromosomal_region]:
@@ -213,7 +212,6 @@ def pileup_to_df(pileup_path: str) -> pd.DataFrame:
     print("pileup_to_df)")
 
     with open(pileup_path, "r") as pu:
-
         lines = pu.readlines()
         lines = [x.split("\t") for x in lines]
         df1 = pd.DataFrame(
@@ -242,7 +240,8 @@ def perbase_table_to_df(table_path):
     except pd.errors.EmptyDataError:
         return pd.DataFrame()
     df["REF_BASE_UPPER"] = df.REF_BASE.str.upper()
-    df["REF_COUNT"] = df.lookup(df.index, df["REF_BASE_UPPER"])
+    idx, cols = pd.factorize(df["REF_BASE_UPPER"])
+    df["REF_COUNT"] = df.reindex(cols, axis=1).to_numpy()[np.arange(len(df)), idx]
     df["ACCURACY"] = df.REF_COUNT / df.DEPTH
     df["Q"] = df.ACCURACY.apply(acc_to_Q)
     df["CHROM"] = df["REF"]
@@ -456,7 +455,6 @@ def make_qscore_scatter(df1, df2, csv_merge=None):
 
 
 def main(perbase_path1, perbase_path2, output_plot_file):
-
     df1 = perbase_table_to_df(perbase_path1)
     df2 = perbase_table_to_df(perbase_path2)
 
@@ -503,7 +501,6 @@ def main(perbase_path1, perbase_path2, output_plot_file):
 
 
 if __name__ == "__main__":
-
     import argparse
 
     parser = argparse.ArgumentParser(

--- a/bin/plot_bam_accuracy.py
+++ b/bin/plot_bam_accuracy.py
@@ -518,13 +518,3 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     main(args.pileup_split, args.pileup_consensus, args.output, args.priority_limit)
-
-    # pileup_split = Path('/home/dami/Data/dev/000010_5/split.tsv')
-    # pileup_cons = Path('/home/dami/Data/dev/000010_5/consensus.tsv')
-    # output = Path('testQ.html')
-    # main(pileup_split, pileup_cons, output)
-
-    # df1 = perbase_table_to_df('/media/dami/a2bc89fb-be6b-4e23-912a-0c7137cd69ad/results/Cyclomics_rc/000010/perbase_test_split.tsv')
-    # df2 = perbase_table_to_df('/media/dami/a2bc89fb-be6b-4e23-912a-0c7137cd69ad/results/Cyclomics_rc/000010/perbase_test.tsv')
-    # plots = plot_compare_accuracy([('chr17',7579983,7580193)], [df1,df2])
-    # show(plots)

--- a/bin/plot_bam_accuracy.py
+++ b/bin/plot_bam_accuracy.py
@@ -12,9 +12,8 @@ import pandas as pd
 import numpy as np
 import re
 
-from bokeh.io import save, output_file
-from bokeh.plotting import figure, show
-from bokeh.layouts import row, column
+from bokeh.plotting import figure
+from bokeh.layouts import column
 from bokeh.embed import components
 from bokeh.layouts import gridplot
 
@@ -467,12 +466,6 @@ def main(perbase_path1, perbase_path2, output_plot_file, priority_limit: int):
         df2 = perbase_table_to_df(perbase_path2)
 
         if df1.empty or df2.empty:
-            f = open(output_plot_file, "w")
-            f.write("<h1>One of the pileups was not deep enough.</h1>")
-            f.close()
-            f = open(output_plot_file.with_suffix(".csv"), "w")
-            f.write("One of the pileups was not deep.")
-            f.close()
             json_obj[tab_name]["script"], json_obj[tab_name]["div"] = (
                 "",
                 "<h1>One of the pileups was not deep enough.</h1>",
@@ -484,19 +477,14 @@ def main(perbase_path1, perbase_path2, output_plot_file, priority_limit: int):
             positional_accuracy = plot_compare_accuracy(
                 roi, [df1, df2], "Variant unaware Q"
             )
-            q_score_plot = make_qscore_scatter(
-                df1, df2, output_plot_file.with_suffix(".csv")
-            )
+            q_score_plot = make_qscore_scatter(df1, df2)
 
-            output_file(output_plot_file, title="Cyclomics accuracy")
             final_plot = column([q_score_plot, positional_accuracy])
 
             json_obj[tab_name]["script"], json_obj[tab_name]["div"] = components(
                 final_plot
             )
             json_obj["additional_info"] = add_info
-
-            save(final_plot)
 
     print("writing json")
     print(Path(output_plot_file).with_suffix(".json"))

--- a/bin/plot_fastq_histograms.py
+++ b/bin/plot_fastq_histograms.py
@@ -88,29 +88,37 @@ def plot_length_hist(lengths, my_title_len):
     return p
 
 
-def main(file_extention, output_file_name, my_title_q, my_title_len, tab_name):
+def main(
+    file_extention,
+    output_file_name,
+    my_title_q,
+    my_title_len,
+    tab_name,
+    priority_limit: int,
+):
+    json_obj = {}
+    json_obj[tab_name] = {}
+    json_obj[tab_name]["name"] = tab_name
+    json_obj[tab_name]["priority"] = TAB_PRIORITY
 
-    Q_scores, lengths = process_fastqs(f"*.{file_extention}")
-    total = sum(Q_scores.values())
-    overall_Q = [[ord(k) - 33, v / total, v] for k, v in Q_scores.items()]
+    if TAB_PRIORITY < priority_limit:
+        Q_scores, lengths = process_fastqs(f"*.{file_extention}")
+        total = sum(Q_scores.values())
+        overall_Q = [[ord(k) - 33, v / total, v] for k, v in Q_scores.items()]
 
-    # print(overall_Q)
-    output_file(filename=output_file_name, title="fastq information")
+        # print(overall_Q)
+        output_file(filename=output_file_name, title="fastq information")
 
-    q_hist = plot_overall_Q_hist(overall_Q, my_title_q)
+        q_hist = plot_overall_Q_hist(overall_Q, my_title_q)
 
-    len_hist = plot_length_hist(lengths, my_title_len)
+        len_hist = plot_length_hist(lengths, my_title_len)
 
-    final_plot = column(q_hist, len_hist)
+        final_plot = column(q_hist, len_hist)
 
-    with open(Path(output_file_name).with_suffix(".json"), "w") as f:
-        json_obj = {}
-        json_obj[tab_name] = {}
-        json_obj[tab_name]["name"] = tab_name
         json_obj[tab_name]["script"], json_obj[tab_name]["div"] = components(final_plot)
         json_obj["additional_info"] = {f"reads{tab_name}": len(lengths)}
-        json_obj[tab_name]["priority"] = TAB_PRIORITY
 
+    with open(Path(output_file_name).with_suffix(".json"), "w") as f:
         f.write(json.dumps(json_obj))
 
     save(final_plot)
@@ -126,12 +134,18 @@ if __name__ == "__main__":
     parser.add_argument("fastq_regex_suffix")
     parser.add_argument("plot_file")
     parser.add_argument("tab_name", default="fastq information")
+    parser.add_argument("priority_limit", type=int, default=89)
     args = parser.parse_args()
 
     my_title_q = f"Q scores relative abundance"
     my_title_len = f"Length distribution"
     main(
-        args.fastq_regex_suffix, args.plot_file, my_title_q, my_title_len, args.tab_name
+        args.fastq_regex_suffix,
+        args.plot_file,
+        my_title_q,
+        my_title_len,
+        args.tab_name,
+        args.priority_limit,
     )
 
     # fastq_file_name = "/media/dami/a2bc89fb-be6b-4e23-912a-0c7137cd69ad/raw_data/Cyclomics/000014/HC01_CG_001/20220630_1612_MN40283_FAT55621_6a2c8b02/fastq_pass/*13.fastq.gz"

--- a/bin/plot_fastq_histograms.py
+++ b/bin/plot_fastq_histograms.py
@@ -11,10 +11,9 @@ from pyfastx import Fastq
 import pandas as pd
 import numpy as np
 
-from bokeh.io import save, output_file, show
 from bokeh.plotting import figure
 from bokeh.models import ColumnDataSource
-from bokeh.layouts import row, column
+from bokeh.layouts import column
 from bokeh.embed import components
 
 from plotting_defaults import cyclomics_defaults
@@ -106,9 +105,6 @@ def main(
         total = sum(Q_scores.values())
         overall_Q = [[ord(k) - 33, v / total, v] for k, v in Q_scores.items()]
 
-        # print(overall_Q)
-        output_file(filename=output_file_name, title="fastq information")
-
         q_hist = plot_overall_Q_hist(overall_Q, my_title_q)
 
         len_hist = plot_length_hist(lengths, my_title_len)
@@ -120,8 +116,6 @@ def main(
 
     with open(Path(output_file_name).with_suffix(".json"), "w") as f:
         f.write(json.dumps(json_obj))
-
-    save(final_plot)
 
 
 if __name__ == "__main__":
@@ -147,9 +141,3 @@ if __name__ == "__main__":
         args.tab_name,
         args.priority_limit,
     )
-
-    # fastq_file_name = "/media/dami/a2bc89fb-be6b-4e23-912a-0c7137cd69ad/raw_data/Cyclomics/000014/HC01_CG_001/20220630_1612_MN40283_FAT55621_6a2c8b02/fastq_pass/*13.fastq.gz"
-    # my_title_q = f"Q scores in all Fastq files found using {fastq_file_name}"
-    # my_title_len = f"Length distribution"
-    # output_file_name = "qscore.html"
-    # main(fastq_file_name, output_file_name, my_title_q,  my_title_len)

--- a/bin/plot_metadata.py
+++ b/bin/plot_metadata.py
@@ -12,14 +12,11 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from bokeh.embed import components
-from bokeh.io import output_file, save
 from bokeh.layouts import column
 from bokeh.models import ColumnDataSource, HoverTool, LabelSet
 from bokeh.plotting import figure
 from bokeh.transform import cumsum
 from plotting_defaults import cyclomics_defaults
-from concurrent.futures import ProcessPoolExecutor, wait, ALL_COMPLETED
-from threading import Lock
 
 raw_len_dt = np.int32
 aln_len_dt = np.int32
@@ -361,14 +358,11 @@ def read_jsons_into_plots(
         figtitle=f"Length vs segments identified (n = {max_points:,})",
     )
 
-    output_file(plot_file, title="metadata plots")
     final_plot = column([p1, p2, p3, p4])
 
     with open(Path(plot_file).with_suffix(".json"), "w") as f:
         json_obj[tab_name]["script"], json_obj[tab_name]["div"] = components(final_plot)
         f.write(json.dumps(json_obj))
-
-    save(final_plot)
 
 
 if __name__ == "__main__":

--- a/bin/plot_metadata.py
+++ b/bin/plot_metadata.py
@@ -278,9 +278,22 @@ def parse_Cycas_metadata(
 def read_jsons_into_plots(
     json_folder,
     plot_file,
+    priority_limit: int,
     subsample_size: int = 10_000,
     seed: int = 42,
 ):
+    # Initialize HTML tab
+    tab_name = "Metadata"
+    json_obj = {}
+    json_obj[tab_name] = {}
+    json_obj[tab_name]["name"] = tab_name
+    json_obj[tab_name]["priority"] = TAB_PRIORITY
+
+    if TAB_PRIORITY > priority_limit:
+        with open(Path(plot_file).with_suffix(".json"), "w") as f:
+            f.write(json.dumps(json_obj))
+        return
+
     nr_reads = 0
     result_stack = []
     for data_json in glob.glob(f"{json_folder}/*.json"):
@@ -309,17 +322,8 @@ def read_jsons_into_plots(
     segments = results[2].astype(segment_dt)
     classifs = results[3].astype(class_dt)
 
-    # Initialize HTML tab
-    tab_name = "Metadata"
-    json_obj = {}
-    json_obj[tab_name] = {}
-    json_obj[tab_name]["name"] = tab_name
-    json_obj[tab_name]["priority"] = TAB_PRIORITY
     # Write out empty file if there are no metadata
     if nr_reads == 0:
-        f = open(plot_file, "w")
-        f.write("<h1>No metadata found.</h1>")
-        f.close()
         json_obj[tab_name]["script"], json_obj[tab_name]["div"] = (
             "",
             "<h1>No metadata found: metadata JSON files were empty.</h1>",
@@ -373,7 +377,11 @@ if __name__ == "__main__":
     dev = False
     if dev:
         read_jsons_into_plots(
-            "./plot_metadata/jsons/", "./metadata.html", subsample_size=0, seed=42
+            "./plot_metadata/jsons/",
+            "./metadata.html",
+            priority_limit=9999,
+            subsample_size=0,
+            seed=42,
         )
 
     else:
@@ -381,13 +389,16 @@ if __name__ == "__main__":
 
         parser.add_argument("json_glob_path")
         parser.add_argument("plot_file")
-        parser.add_argument("--subsample_size", default=10_000)
-        parser.add_argument("--seed", default=42)
+        parser.add_argument("priority_limit", type=int, default=89)
+        parser.add_argument("--subsample_size", type=int, default=10_000)
+        parser.add_argument("--seed", type=int, default=42)
+
         args = parser.parse_args()
 
         read_jsons_into_plots(
             args.json_glob_path,
             args.plot_file,
-            int(args.subsample_size),
-            int(args.seed),
+            args.priority_limit,
+            args.subsample_size,
+            args.seed,
         )

--- a/bin/plot_read_structure_donut.py
+++ b/bin/plot_read_structure_donut.py
@@ -292,6 +292,7 @@ def create_readtype_donuts(
         donut_plot.title.text_font_size = "16pt"
         return donut_plot
 
+    tab_name = "Read structure"
     json_obj = {}
     json_obj[tab_name] = {}
     json_obj[tab_name]["name"] = tab_name
@@ -330,7 +331,6 @@ def create_readtype_donuts(
 
         donut_row = row(p1, p2)
         donut_plot = column(Div(text=f"<h1>{plot_title}</h1>"), donut_row)
-        tab_name = "Read structure"
 
         json_obj[tab_name]["script"], json_obj[tab_name]["div"] = components(donut_plot)
         json_obj["additional_info"] = add_info

--- a/bin/plot_vcf.py
+++ b/bin/plot_vcf.py
@@ -7,9 +7,8 @@ import numpy as np
 from pathlib import Path
 import json
 
-from bokeh.io import save, output_file
-from bokeh.plotting import figure, show
-from bokeh.layouts import row, column
+from bokeh.plotting import figure
+from bokeh.layouts import column
 from bokeh.models import HoverTool
 from bokeh.embed import components
 
@@ -228,8 +227,6 @@ def main(vcf_file, plot_file, priority_limit: int):
         roi = get_roi_pileup_df(data)
         # print(data)
         plot = make_scatter_plots(data, roi)
-        output_file(plot_file, title="variant plots")
-        save(plot)
 
         json_obj[tab_name]["script"], json_obj[tab_name]["div"] = components(plot)
 

--- a/bin/write_variants_table.py
+++ b/bin/write_variants_table.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pandas as pd
 import io
 
-from plotting_defaults import cyclomics_defaults, human_format
+from plotting_defaults import human_format
 
 TAB_PRIORITY = 2
 

--- a/main.nf
+++ b/main.nf
@@ -38,6 +38,7 @@ params.report                   = true
 params.split_on_adapter         = false
 params.sequence_summary_tagging = false
 params.backbone_file            = ""
+params.priority_limit = (params.report == "detailed") ? 9999 : 89
 
 // Pipeline performance metrics
 params.min_repeat_count = 3
@@ -111,6 +112,7 @@ if (params.profile_selected == "conda"){
 include {
     DetailedReport
     StandardReport
+    Report
 } from "./subworkflows/QC"
 
 include {
@@ -139,9 +141,9 @@ include {
     ValidatePosibleVariantLocations
 } from "./subworkflows/variant_calling"
 
-include {
-    Report
-} from "./subworkflows/report"
+// include {
+//     Report
+// } from "./subworkflows/report"
 
 /*
 ========================================================================================
@@ -314,23 +316,8 @@ workflow {
 04.    Reporting
 ========================================================================================
 */  
-    if (params.report == "detailed"){
-        DetailedReport(
-            PrepareGenome.out.fasta_combi,
-            read_fastq,
-            read_fastq_filtered,
-            split_bam,
-            split_bam_filtered,
-            base_unit_reads,
-            read_info_json,
-            reads_aligned_filtered,
-            regions,
-            locations,
-            variant_vcf,
-        )
-    }
-    else if (params.report == "standard") {
-        StandardReport(
+    if (params.report in ["detailed", "standard"]){
+        Report(
             PrepareGenome.out.fasta_combi,
             read_fastq,
             read_fastq_filtered,

--- a/main.nf
+++ b/main.nf
@@ -110,8 +110,6 @@ if (params.profile_selected == "conda"){
 ========================================================================================
 */
 include {
-    DetailedReport
-    StandardReport
     Report
 } from "./subworkflows/QC"
 

--- a/subworkflows/QC.nf
+++ b/subworkflows/QC.nf
@@ -44,7 +44,7 @@ include{
 } from "./modules/utils"
 
 
-workflow StandardReport {
+workflow Report {
     take:
         reference_fasta
         fastq_raw
@@ -79,89 +79,21 @@ workflow StandardReport {
         PlotConFastqHist(fastq_consensus.map(it -> it[1]).collect(),extension, id + "consensus", '"Consensus fastq info"')
 
         merged_split_bam = SamtoolsMergeBams('splibams_merged', split_bam.collect())
-        PlotReadStructure(merged_split_bam)
-        SamtoolsQuickcheck(consensus_bam)
-        SamtoolsIdxStats(consensus_bam)
-        CountNonBackboneVariants(variants_vcf)
-        meta_data = read_info.map(it -> it[1]).collect()
-        PlotMetadataStats(meta_data)
-
-        // roi = FindRegionOfInterest(consensus_bam)
-      
-        PerbaseBaseDepthSplit(merged_split_bam.combine(reference_fasta), roi, 'split.tsv')
-        PerbaseBaseDepthConsensus(consensus_bam.combine(reference_fasta), roi, 'consensus.tsv')
-
-        PlotQScores(PerbaseBaseDepthSplit.out, PerbaseBaseDepthConsensus.out)
-        PlotVcf(noisy_vcf)
-
-        merged_split_bam_filtered = SamtoolsMergeBamsFiltered('splibams_filtered_merged',split_bam_filtered.collect())
-        SamtoolsFlagstats(merged_split_bam_filtered)
-
-        PasteVariantTable(variants_vcf)
-        PlotReportStd(
-            PlotRawFastqHist.out.combine(
-            PlotFilteredHist.out).combine(
-            PlotConFastqHist.out).combine(
-            PlotReadStructure.out).combine(
-            PlotQScores.out).combine(
-            PlotVcf.out).combine(
-            PlotMetadataStats.out).combine(
-            PasteVariantTable.out).combine(
-            SamtoolsFlagstats.out).combine(
-            CountNonBackboneVariants.out).combine(
-            SamtoolsIdxStats.out
-            )
-        )
-}
-
-workflow DetailedReport {
-    take:
-        reference_fasta
-        fastq_raw
-        fastq_filtered
-        split_bam
-        split_bam_filtered
-        fastq_consensus
-        read_info
-        consensus_bam
-        roi
-        noisy_vcf
-        variants_vcf
-
-    main:
-        // dont add the ID to the process
-        first_fq = fastq_raw.first()
-        id = first_fq.simpleName
-        extension = first_fq.getExtension()
-        FastqInfoRaw(fastq_raw.collect(),'raw')
-        PlotRawFastqHist(fastq_raw.collect(), extension, id + "raw", '"Raw fastq info"')
+        PlotReadStructure(merged_split_bam) // 90
         
-        first_fq = fastq_filtered.first()
-        id = first_fq.simpleName
-        extension = first_fq.getExtension()
-        PlotFilteredHist(fastq_filtered.collect(),extension, id + "filtered", '"Filtered fastq info"')
-
-        first_fq = fastq_consensus.first()
-        id = first_fq.map(it -> it[0])
-        extension = first_fq.map(it -> it[1]).getExtension()
-
-        FastqInfoConsensus(fastq_consensus.map(it -> it[1]).collect(), 'consensus')
-        PlotConFastqHist(fastq_consensus.map(it -> it[1]).collect(),extension, id + "consensus", '"Consensus fastq info"')
-
-        merged_split_bam = SamtoolsMergeBams('splibams_merged', split_bam.collect())
-        PlotReadStructure(merged_split_bam)
         SamtoolsQuickcheck(consensus_bam)
         SamtoolsIdxStats(consensus_bam)
         CountNonBackboneVariants(variants_vcf)
+
         meta_data = read_info.map(it -> it[1]).collect()
-        PlotMetadataStats(meta_data)
+        PlotMetadataStats(meta_data) // 92
 
         // roi = FindRegionOfInterest(consensus_bam)
       
         PerbaseBaseDepthSplit(merged_split_bam.combine(reference_fasta), roi, 'split.tsv')
         PerbaseBaseDepthConsensus(consensus_bam.combine(reference_fasta), roi, 'consensus.tsv')
-
-        PlotQScores(PerbaseBaseDepthSplit.out, PerbaseBaseDepthConsensus.out)
+        PlotQScores(PerbaseBaseDepthSplit.out, PerbaseBaseDepthConsensus.out) // 91
+        
         PlotVcf(noisy_vcf)
 
         merged_split_bam_filtered = SamtoolsMergeBamsFiltered('splibams_filtered_merged',split_bam_filtered.collect())

--- a/subworkflows/QC.nf
+++ b/subworkflows/QC.nf
@@ -11,8 +11,7 @@ include {
     PasteVariantTable
     PlotQScores
     PlotMetadataStats
-    PlotReportDetailed
-    PlotReportStd
+    PlotReport
 } from "./modules/bin"
 
 include {
@@ -100,12 +99,12 @@ workflow Report {
         SamtoolsFlagstats(merged_split_bam_filtered)
 
         PasteVariantTable(variants_vcf)
-        PlotReportDetailed(
+        PlotReport(
             PlotRawFastqHist.out.combine(
             PlotFilteredHist.out).combine(
             PlotConFastqHist.out).combine(
             PlotReadStructure.out).combine(
-            PlotQScores.out).combine(
+            PlotQScores.out).combine( // try making this fail
             PlotVcf.out).combine(
             PlotMetadataStats.out).combine(
             PasteVariantTable.out).combine(

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -208,6 +208,7 @@ process PlotFastqsQUalAndLength{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
     publishDir "${params.output_dir}/QC", mode: 'copy'
     label 'many_low_cpu_high_mem'
+    errorStrategy 'ignore'
 
     input:
         path(fastq)
@@ -231,7 +232,7 @@ process PlotReadStructure{
     label 'many_cpu_medium'
 
     memory { task.memory * task.attempt }
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'ignore' }
     maxRetries 3
 
     input:
@@ -256,7 +257,7 @@ process PlotVcf{
     publishDir "${params.output_dir}/QC", mode: 'copy'
     label 'many_low_cpu_high_mem'
     memory { task.memory * task.attempt }
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'ignore' }
     maxRetries 3
 
     input:
@@ -276,6 +277,7 @@ process PlotVcf{
 process PasteVariantTable{
     publishDir "${params.output_dir}/QC", mode: 'copy'
     label 'many_low_cpu_high_mem'
+    errorStrategy 'ignore'
 
     input:
         path(vcf_file)
@@ -315,7 +317,7 @@ process PlotMetadataStats{
     publishDir "${params.output_dir}/QC", mode: 'copy'
     label 'many_low_cpu_huge_mem'
     memory { task.memory * task.attempt }
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'ignore' }
     maxRetries 3
 
     input:

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -1,6 +1,3 @@
-
-
-
 process AddDepthToJson{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
     label 'many_cpu_medium'
@@ -219,11 +216,12 @@ process PlotFastqsQUalAndLength{
         val tab_name
 
     output:
-        tuple path("${plot_file_prefix}_histograms.html"), path("${plot_file_prefix}_histograms.json")
+        path("${plot_file_prefix}_histograms.json")
     
     script:
         """
-        plot_fastq_histograms.py $grep_pattern ${plot_file_prefix}_histograms.html $tab_name $params.priority_limit
+        plot_fastq_histograms.py $grep_pattern ${plot_file_prefix}_histograms.html $tab_name $params.priority_limit \
+        2> >(tee -a error.txt >&2) || catch_plotting_errors.sh error.txt ${plot_file_prefix}_histograms.json
         """
 }
 
@@ -240,13 +238,17 @@ process PlotReadStructure{
         tuple val(X), path(bam), path(bai)
 
     output:
-        tuple path("${bam.simpleName}_aligned_segments.html"), path("${bam.simpleName}_read_structure.html"), path("${bam.simpleName}_read_structure.json")
+        path("${bam.simpleName}_read_structure.json")
 
     script:
         // This takes a lot of RAM when the sequencing summary is big!
         """
         samtools sort -n -o tmp_readname_sorted_${bam.simpleName}.bam ${bam}
-        plot_read_structure_donut.py tmp_readname_sorted_${bam.simpleName}.bam ${bam.simpleName}_aligned_segments.html ${bam.simpleName}_read_structure.html $params.priority_limit
+        plot_read_structure_donut.py tmp_readname_sorted_${bam.simpleName}.bam \
+        ${bam.simpleName}_aligned_segments.html \
+        ${bam.simpleName}_read_structure.html \
+        $params.priority_limit \
+        2> >(tee -a error.txt >&2) || catch_plotting_errors.sh error.txt ${bam.simpleName}_read_structure.json
         """
 }
 
@@ -262,12 +264,13 @@ process PlotVcf{
         path(vcf)
 
     output:
-        tuple path("${vcf.simpleName}.html"), path("${vcf.simpleName}.json")
+        path("${vcf.simpleName}.json")
     
     script:
         // This takes a lot of RAM when the sequencing summary is big!
         """
-        plot_vcf.py $vcf ${vcf.simpleName}.html $params.priority_limit
+        plot_vcf.py $vcf ${vcf.simpleName}.html $params.priority_limit \
+        2> >(tee -a error.txt >&2) || catch_plotting_errors.sh error.txt ${vcf.simpleName}.json
         """
 }
 
@@ -283,7 +286,8 @@ process PasteVariantTable{
     
     script:
         """
-        write_variants_table.py $vcf_file ${vcf_file.simpleName}_table.json 'Variant table' $params.priority_limit
+        write_variants_table.py $vcf_file ${vcf_file.simpleName}_table.json 'Variant table' $params.priority_limit \
+        2> >(tee -a error.txt >&2) || catch_plotting_errors.sh error.txt ${vcf_file.simpleName}_table.json
         """
 }
 
@@ -291,17 +295,19 @@ process PlotQScores{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
     publishDir "${params.output_dir}/QC", mode: 'copy'
     label 'many_low_cpu_high_mem'
+    errorStrategy 'ignore'
 
     input:
         tuple val(X), path(split_pileup)
         tuple val(Y), path(consensus_pileup)
 
     output:
-        tuple path("${consensus_pileup.simpleName}.html"), path("${consensus_pileup.simpleName}.csv"), path("${consensus_pileup.simpleName}.json")
+        path("${consensus_pileup.simpleName}.json")
     
     script:
         """
-        plot_bam_accuracy.py $split_pileup $consensus_pileup ${consensus_pileup.simpleName}.html $params.priority_limit
+        plot_bam_accuracy.py $split_pileup $consensus_pileup ${consensus_pileup.simpleName}.html $params.priority_limit \
+        2> >(tee -a error.txt >&2) || catch_plotting_errors.sh error.txt ${consensus_pileup.simpleName}.json
         """
 }
 
@@ -317,11 +323,12 @@ process PlotMetadataStats{
         path(jsons)
 
     output:
-        tuple path("metadata_plots.html"), path("metadata_plots.json")
+        path("metadata_plots.json")
     
     script:
         """
-        plot_metadata.py . metadata_plots.html $params.priority_limit --subsample_size $params.metadata.subsample_size
+        plot_metadata.py . metadata_plots.html $params.priority_limit --subsample_size $params.metadata.subsample_size \
+        2> >(tee -a error.txt >&2) || catch_plotting_errors.sh error.txt metadata_plots.json
         """
 }
 

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -245,8 +245,7 @@ process PlotReadStructure{
         """
         samtools sort -n -o tmp_readname_sorted_${bam.simpleName}.bam ${bam}
         plot_read_structure_donut.py tmp_readname_sorted_${bam.simpleName}.bam \
-        ${bam.simpleName}_aligned_segments.html \
-        ${bam.simpleName}_read_structure.html \
+        ${bam.simpleName}_read_structure.json \
         $params.priority_limit \
         2> >(tee -a error.txt >&2) || catch_plotting_errors.sh error.txt ${bam.simpleName}_read_structure.json
         """

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -223,7 +223,7 @@ process PlotFastqsQUalAndLength{
     
     script:
         """
-        plot_fastq_histograms.py $grep_pattern ${plot_file_prefix}_histograms.html $tab_name
+        plot_fastq_histograms.py $grep_pattern ${plot_file_prefix}_histograms.html $tab_name $params.priority_limit
         """
 }
 
@@ -246,7 +246,7 @@ process PlotReadStructure{
         // This takes a lot of RAM when the sequencing summary is big!
         """
         samtools sort -n -o tmp_readname_sorted_${bam.simpleName}.bam ${bam}
-        plot_read_structure_donut.py tmp_readname_sorted_${bam.simpleName}.bam ${bam.simpleName}_aligned_segments.html ${bam.simpleName}_read_structure.html
+        plot_read_structure_donut.py tmp_readname_sorted_${bam.simpleName}.bam ${bam.simpleName}_aligned_segments.html ${bam.simpleName}_read_structure.html $params.priority_limit
         """
 }
 
@@ -267,7 +267,7 @@ process PlotVcf{
     script:
         // This takes a lot of RAM when the sequencing summary is big!
         """
-        plot_vcf.py $vcf ${vcf.simpleName}.html
+        plot_vcf.py $vcf ${vcf.simpleName}.html $params.priority_limit
         """
 }
 
@@ -283,7 +283,7 @@ process PasteVariantTable{
     
     script:
         """
-        write_variants_table.py $vcf_file ${vcf_file.simpleName}_table.json 'Variant table'
+        write_variants_table.py $vcf_file ${vcf_file.simpleName}_table.json 'Variant table' $params.priority_limit
         """
 }
 
@@ -301,7 +301,7 @@ process PlotQScores{
     
     script:
         """
-        plot_bam_accuracy.py $split_pileup $consensus_pileup ${consensus_pileup.simpleName}.html
+        plot_bam_accuracy.py $split_pileup $consensus_pileup ${consensus_pileup.simpleName}.html $params.priority_limit
         """
 }
 
@@ -321,11 +321,11 @@ process PlotMetadataStats{
     
     script:
         """
-        plot_metadata.py . metadata_plots.html --subsample_size $params.metadata.subsample_size
+        plot_metadata.py . metadata_plots.html $params.priority_limit --subsample_size $params.metadata.subsample_size
         """
 }
 
-process PlotReportDetailed{
+process PlotReport{
     publishDir "${params.output_dir}", mode: 'copy'
     label 'many_low_cpu_high_mem'
 
@@ -337,22 +337,6 @@ process PlotReportDetailed{
     
     script:
         """
-        generate_report.py '${params}' $workflow.manifest.version 9999
-        """
-}
-
-process PlotReportStd{
-    publishDir "${params.output_dir}", mode: 'copy'
-    label 'many_low_cpu_high_mem'
-
-    input:
-        path(jsons)
-
-    output:
-        path("report.html")
-    
-    script:
-        """
-        generate_report.py '${params}' $workflow.manifest.version 89
+        generate_report.py '${params}' $workflow.manifest.version $params.priority_limit
         """
 }


### PR DESCRIPTION
- Substitute deprecated `pd.lookup` for `pd.factorize` while parsing perbase tables
- Make priority limit an argument to plotting scripts
- Only execute plotting if priority is lower integer than priority limit
- Propagate plotting error messages to a JSON file that will show in place of its respective plot, in its respective report tab
- If a plot fails, continue the workflow (`errorStrategy 'ignore'`)
- If a plotting error occurs, issue a card to the top of the report with a warning