### PR TITLE
Activate dynamic variant filtering for 'validate' variant calling

### DIFF
--- a/bin/determine_vaf.py
+++ b/bin/determine_vaf.py
@@ -210,25 +210,14 @@ if __name__ == "__main__":
         main(args.fasta, args.bed, args.bam, args.snp_vcf_out, args.indel_vcf_out)
 
     if dev:
-        # EGFR
-        # fasta = Path(
-        #     "/data/references/Homo_sapiens/GRCh38.p14/GCA_000001405.29_GRCh38.p14_genomic.fna"
-        # )
-        # bed = Path("/data/projects/ROD_1125_variant_improvements/EGFR.bed")
-        # bam = Path(
-        #     "/data/projects/ROD_1125_variant_improvements/ONT_20221121_EGFR/consensus_aligned/284.taged.bam"
-        # )
-        # snp_vcf_out = Path("/data/projects/DAM_0111_vc_multi/testsnp_EGFR.vcf")
-        # indel_vcf_out = Path("/data/projects/DAM_0111_vc_multi/testindel_EGFR.vcf")
-
         fasta = Path(
-            "/scratch/nxf_work/dami/b6/b1293bac824269db94893b246f0829/GCA_000001405_BB42.fasta"
+            "/data/projects/ROD_tmp/2f/2da9d6bfb181300787503ab54f79de/GRCh38_renamed_BBCS.fasta"
         )
         bed = Path(
-            "/scratch/nxf_work/dami/b6/b1293bac824269db94893b246f0829/FAV97214_roi.bed"
+            "/data/projects/ROD_tmp/2f/2da9d6bfb181300787503ab54f79de/FAW08675_roi.bed"
         )
         bam = Path(
-            "/scratch/nxf_work/dami/b6/b1293bac824269db94893b246f0829/FAV97214.YM_gt_3.bam"
+            "/data/projects/ROD_tmp/2f/2da9d6bfb181300787503ab54f79de/FAW08675.YM_gt_3.bam"
         )
         snp_vcf_out = Path("./test_snp.vcf")
         indel_vcf_out = Path("./test_indel.vcf")

--- a/bin/variant_calling/detect_indel.py
+++ b/bin/variant_calling/detect_indel.py
@@ -306,7 +306,7 @@ def extract_indel_evidence(
             info = {
                 "TYPE": indel.type,
                 "DP": vcf_entry.DP,
-                "QA": vcf_entry.ABQ,
+                "QA": vcf_entry.ABQ * vcf_entry.TOTC,
                 "AO": vcf_entry.TOTC,
                 "SAF": vcf_entry.FWDC,
                 "SAR": vcf_entry.REVC,

--- a/bin/variant_calling/detect_indel.py
+++ b/bin/variant_calling/detect_indel.py
@@ -386,8 +386,10 @@ def main(
 
                     r.samples["SAMPLE1"][fld.name] = fld_entry
 
-                for k, v in result[3].items():
-                    r.info[k] = v
+                # Write info tag values to VCF output
+                # These values will be used to filter the VCF
+                for tag_id, value in result[3].items():
+                    r.info[tag_id] = value
 
                 vcf.write(r)
 

--- a/bin/variant_calling/detect_snp.py
+++ b/bin/variant_calling/detect_snp.py
@@ -226,10 +226,12 @@ def extract_snp_evidence(
         vcf_entry.OBQ = quals_mean
         vcf_entry.HCR = hc_ratio
 
+        if pileupcolumn.reference_pos == 7675087:
+            print("hi")
         info = {
             "TYPE": "snp",
             "DP": vcf_entry.DP,
-            "QA": vcf_entry.ABQ,
+            "QA": vcf_entry.ABQ * vcf_entry.TOTC,
             "AO": vcf_entry.TOTC,
             "SAF": vcf_entry.FWDC,
             "SAR": vcf_entry.REVC,
@@ -336,13 +338,13 @@ if __name__ == "__main__":
 
     if dev:
         fasta = Path(
-            "/data/projects/ROD_tmp/2f/2da9d6bfb181300787503ab54f79de/GRCh38_renamed_BBCS.fasta"
+            "/data/projects/ROD_tmp/0a/cbe3196164fe5d443ba018f1bb5098/GRCh38_renamed_BBCS.fasta"
         )
         bed = Path(
-            "/data/projects/ROD_tmp/2f/2da9d6bfb181300787503ab54f79de/FAW08675_roi.bed"
+            "/data/projects/ROD_tmp/0a/cbe3196164fe5d443ba018f1bb5098/FAU75373_roi.bed"
         )
         bam = Path(
-            "/data/projects/ROD_tmp/2f/2da9d6bfb181300787503ab54f79de/FAW08675.YM_gt_3.bam"
+            "/data/projects/ROD_tmp/0a/cbe3196164fe5d443ba018f1bb5098/FAU75373.YM_gt_3.bam"
         )
         vcf_out = Path("./test.vcf")
 

--- a/bin/variant_calling/detect_snp.py
+++ b/bin/variant_calling/detect_snp.py
@@ -34,6 +34,7 @@ def extract_snp_evidence(
 
     vcf_entry = VCF_entry()
     alleles = (ref_nt, ".")
+    info = "."
 
     total = 0
     counted_nucs = 0
@@ -225,7 +226,16 @@ def extract_snp_evidence(
         vcf_entry.OBQ = quals_mean
         vcf_entry.HCR = hc_ratio
 
-    return (assembly, alleles, vcf_entry)
+        info = {
+            "TYPE": "snp",
+            "DP": vcf_entry.DP,
+            "QA": vcf_entry.ABQ,
+            "AO": vcf_entry.TOTC,
+            "SAF": vcf_entry.FWDC,
+            "SAR": vcf_entry.REVC,
+        }
+
+    return (assembly, alleles, vcf_entry, info)
 
 
 def main(
@@ -291,7 +301,10 @@ def main(
                     else:
                         fld_entry = str(fld_value)
 
-                    r.samples["SAMPLE"][fld.name] = fld_entry
+                    r.samples["SAMPLE1"][fld.name] = fld_entry
+
+                for k, v in result[3].items():
+                    r.info[k] = v
 
                 vcf.write(r)
 
@@ -322,16 +335,15 @@ if __name__ == "__main__":
         main(args.bam, args.variant_bed, args.file_out)
 
     if dev:
-        # PNK_01
         fasta = Path(
-            "/scratch/nxf_work/rodrigo/fe/531d9c9f51cadbc31e59f657fdd523/GCA_000001405_BB42.fasta"
+            "/data/projects/ROD_tmp/2f/2da9d6bfb181300787503ab54f79de/GRCh38_renamed_BBCS.fasta"
         )
         bed = Path(
-            "/scratch/nxf_work/rodrigo/fe/531d9c9f51cadbc31e59f657fdd523/FAV97214_roi.bed"
+            "/data/projects/ROD_tmp/2f/2da9d6bfb181300787503ab54f79de/FAW08675_roi.bed"
         )
         bam = Path(
-            "/scratch/nxf_work/rodrigo/fe/531d9c9f51cadbc31e59f657fdd523/FAV97214.YM_gt_3.bam"
+            "/data/projects/ROD_tmp/2f/2da9d6bfb181300787503ab54f79de/FAW08675.YM_gt_3.bam"
         )
-        vcf_out = Path("./test2_snp.vcf")
+        vcf_out = Path("./test.vcf")
 
         main(bam, bed, fasta, vcf_out)

--- a/bin/variant_calling/detect_snp.py
+++ b/bin/variant_calling/detect_snp.py
@@ -226,8 +226,6 @@ def extract_snp_evidence(
         vcf_entry.OBQ = quals_mean
         vcf_entry.HCR = hc_ratio
 
-        if pileupcolumn.reference_pos == 7675087:
-            print("hi")
         info = {
             "TYPE": "snp",
             "DP": vcf_entry.DP,

--- a/bin/variant_calling/vcf_file.py
+++ b/bin/variant_calling/vcf_file.py
@@ -193,7 +193,7 @@ class Vcf:
         self,
         depth_table: pd.DataFrame,
         dynamic_vaf_params: dict,
-        min_ao: int = 0,
+        min_ao: int = 10,
         min_dpq: int = 5_000,
         min_dpq_n: int = 25,
         min_dpq_ratio: float = 0.3,
@@ -208,19 +208,18 @@ class Vcf:
             depth_table: Perbase depth table as a pandas DataFrame, used with
                 min_dpq_n and min_dpq_ratio to calculate local depth maxima and
                 apply a minimum depth filter based on local maxima.
-            min_dir_ratio: Minimum ratio of variant-supporting reads in
-                each direction (default: 0.001).
-            min_dir_count: Minimum number of variant-supporting reads in
-                each direction (default: 5).
-            min_dpq: Minimum positional depth after Q filtering (default: 5_000).
+            dynamic_vaf_params: Input file with params for Dynamic VAF filtering.
+            min_ao: Minimum number of variant-supporting reads.
+            min_dpq: Minimum positional depth after Q filtering.
             min_dpq_n: Number of flanking nucleotides to the each position that will
-                determine the window size for local maxima calculation (default: 25).
+                determine the window size for local maxima calculation.
             min_dpq_ratio: Ratio of local depth maxima that will determine the
-                minimum depth at each position (default: 0.3).
-            min_vaf: Minimum variant allele frequency (default: 0.003).
+                minimum depth at each position.
+            max_sap: Maximum Phred-scaled strand balance probability before
+                alternative allele is considered strand-imbalanced.
             min_rel_ratio: Minimum relative ratio between forward and reverse
-                variant-supporting reads (default: 0.3).
-            min_abq: Minimum average base quality (default: 70).
+                variant-supporting reads.
+            min_abq: Minimum average base quality.
         """
         # nothing to filter
         if self.table.empty:

--- a/bin/variant_calling/vcf_tools.py
+++ b/bin/variant_calling/vcf_tools.py
@@ -93,6 +93,9 @@ def write_vcf_entry(vcf, contig, pos, vcf_entry):
 
         r.samples["SAMPLE1"][fld.name] = fld_entry
 
+    for k, v in vcf_entry[3].items():
+        r.info[k] = v
+
     vcf.write(r)
 
 
@@ -121,7 +124,7 @@ def initialize_output_vcf(vcf_path, contigs):
     for contig in contigs:
         vcfh.add_meta("contig", items=[("ID", contig)])
 
-    # Add GT to FORMAT in our VCF header
+    # Add to FORMAT in our VCF header
     vcfh.add_meta(
         "FORMAT",
         items=[
@@ -258,6 +261,62 @@ def initialize_output_vcf(vcf_path, contigs):
             ("Number", 1),
             ("Type", "String"),
             ("Description", "high quality ratio"),
+        ],
+    )
+
+    # Add to INFO in our VCF header
+    vcfh.add_meta(
+        "INFO",
+        items=[
+            ("ID", "QA"),
+            ("Number", 1),
+            ("Type", "Float"),
+            ("Description", "Alternate allele quality sum in phred"),
+        ],
+    )
+    vcfh.add_meta(
+        "INFO",
+        items=[
+            ("ID", "AO"),
+            ("Number", 1),
+            ("Type", "Integer"),
+            ("Description", "Count of full observations of this alternate haplotype."),
+        ],
+    )
+    vcfh.add_meta(
+        "INFO",
+        items=[
+            ("ID", "DP"),
+            ("Number", 1),
+            ("Type", "Integer"),
+            ("Description", "Total read depth at the locus"),
+        ],
+    )
+    vcfh.add_meta(
+        "INFO",
+        items=[
+            ("ID", "TYPE"),
+            ("Number", 1),
+            ("Type", "String"),
+            ("Description", "The type of allele, either snp, ins, or del."),
+        ],
+    )
+    vcfh.add_meta(
+        "INFO",
+        items=[
+            ("ID", "SAF"),
+            ("Number", 1),
+            ("Type", "Integer"),
+            ("Description", "Number of alternate observations on the forward strand"),
+        ],
+    )
+    vcfh.add_meta(
+        "INFO",
+        items=[
+            ("ID", "SAR"),
+            ("Number", 1),
+            ("Type", "Integer"),
+            ("Description", "Number of alternate observations on the reverse strand"),
         ],
     )
     vcfh.add_meta(

--- a/bin/vcf_filter.py
+++ b/bin/vcf_filter.py
@@ -43,6 +43,13 @@ def parse_arguments():
         help="Input file with params for Dynamic VAF filtering.",
     )
     parser.add_argument(
+        "--min_ao",
+        type=float,
+        required=False,
+        default=10,
+        help="Minimum number of variant-supporting reads (default: 10).",
+    )
+    parser.add_argument(
         "--min_dpq",
         type=float,
         required=False,
@@ -118,6 +125,7 @@ if __name__ == "__main__":
         vcf.filter(
             depth_table,
             dynamic_vaf_params,
+            args.min_ao,
             args.min_dpq,
             args.min_dpq_n,
             args.min_dpq_ratio,
@@ -129,13 +137,11 @@ if __name__ == "__main__":
 
     if dev:
         depth_table = get_depth_table(
-            "/data/projects/ROD_tmp/da/e71cac3aa901e3f633be128a5e406d/consensus.tsv"
+            "/data/projects/ROD_tmp/12/185a02b62002797de024cbdb0a374c/consensus.tsv"
         )
         dynamic_vaf_params = get_dynamic_vaf_params(
             "./bin/variant_calling/dynamic_vaf_params.yml"
         )
-        vcf = Vcf(
-            "/data/projects/ROD_tmp/da/e71cac3aa901e3f633be128a5e406d/FAW08675.snp.vcf"
-        )
+        vcf = Vcf("./test.vcf")
         vcf.filter(depth_table, dynamic_vaf_params, max_sap=0)
         vcf.write("./filtered_snp.vcf")

--- a/bin/vcf_filter_freebayes.py
+++ b/bin/vcf_filter_freebayes.py
@@ -128,8 +128,14 @@ if __name__ == "__main__":
         vcf.write(args.output_vcf)
 
     if dev:
-        depth_table = get_depth_table("./L7154-000200.tsv")
-        dynamic_vaf_params = get_dynamic_vaf_params("./bin/vcf/dynamic_vaf_params.yml")
-        vcf = Vcf("./200.norm.vcf")
-        vcf.filter(depth_table, dynamic_vaf_params)
-        vcf.write("./filtered_200.norm.vcf")
+        depth_table = get_depth_table(
+            "/data/projects/ROD_tmp/da/e71cac3aa901e3f633be128a5e406d/consensus.tsv"
+        )
+        dynamic_vaf_params = get_dynamic_vaf_params(
+            "./bin/variant_calling/dynamic_vaf_params.yml"
+        )
+        vcf = Vcf(
+            "/data/projects/ROD_tmp/da/e71cac3aa901e3f633be128a5e406d/FAW08675.snp.vcf"
+        )
+        vcf.filter(depth_table, dynamic_vaf_params, max_sap=0)
+        vcf.write("./filtered_snp.vcf")

--- a/nextflow.config
+++ b/nextflow.config
@@ -146,6 +146,7 @@ params{
   dynamic_vaf_params_file = "${projectDir}/bin/variant_calling/dynamic_vaf_params.yml"
 
   var_filters{
+    min_ao              = 10
     min_dpq             = 5_000
     min_dpq_n           = 25
     min_dpq_ratio       = 0.3
@@ -155,23 +156,19 @@ params{
   }
 
   snp_filters{
-    min_dir_ratio       = 0.001
-    min_dir_count       = 5
+    min_ao              = 10
     min_dpq             = 5_000
     min_dpq_n           = 25
     min_dpq_ratio       = 0.3
-    min_vaf             = 0.0030
     min_rel_ratio       = 0.3
     min_abq             = 70
   }
 
   indel_filters{
-    min_dir_ratio       = 0.002
-    min_dir_count       = 5
+    min_ao              = 10
     min_dpq             = 5_000
     min_dpq_n           = 25
     min_dpq_ratio       = 0.3
-    min_vaf             = 0.004
     min_rel_ratio       = 0.4
     min_abq             = 70
   }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -174,17 +174,11 @@
       "description": "Options to fine tune SNP and indel variants that are reported by the workflow, using the 'validate' option.",
       "default": "",
       "properties": {
-        "snp_filters.min_dir_ratio": {
-          "type": "number",
-          "description": "Minimum ratio of variant-supporting reads in each direction.",
-          "help_text": "Default:  001",
-          "default": 0.001
-        },
-        "snp_filters.min_dir_count": {
+        "snp_filters.min_ao": {
           "type": "integer",
-          "description": "Minimum number of variant-supporting reads in each direction.",
-          "help_text": "Default: 5",
-          "default": 5
+          "description": "Minimum number of variant-supporting reads.",
+          "help_text": "Default: 10 ",
+          "default": 10
         },
         "snp_filters.min_dpq": {
           "type": "integer",
@@ -204,12 +198,6 @@
           "help_text": "Default: 0.3 ",
           "default": 0.3
         },
-        "snp_filters.min_vaf": {
-          "type": "number",
-          "description": "Minimum variant allele frequency.",
-          "help_text": "Default:  0030",
-          "default": 0.003
-        },
         "snp_filters.min_rel_ratio": {
           "type": "number",
           "description": "Minimum relative ratio between forward and reverse variant-supporting reads",
@@ -222,16 +210,11 @@
           "help_text": "Default: 70 ",
           "default": 70
         },
-        "indel_filters.min_dir_ratio": {
-          "type": "number",
-          "description": "Minimum ratio of variant-supporting reads in each direction.",
-          "default": 0.002
-        },
-        "indel_filters.min_dir_count": {
+        "indel_filters.min_ao": {
           "type": "integer",
-          "description": "Minimum number of variant-supporting reads in each direction.",
-          "help_text": "Default: 5",
-          "default": 5
+          "description": "Minimum number of variant-supporting reads.",
+          "help_text": "Default: 10 ",
+          "default": 10
         },
         "indel_filters.min_dpq": {
           "type": "integer",
@@ -250,12 +233,6 @@
           "description": "Ratio of local depth maxima that will determine the minimum depth at each position",
           "help_text": "Default: 0.3 ",
           "default": 0.3
-        },
-        "indel_filters.min_vaf": {
-          "type": "number",
-          "description": "Minimum variant allele frequency.",
-          "help_text": "Default:  0040",
-          "default": 0.004
         },
         "indel_filters.min_rel_ratio": {
           "type": "number",
@@ -277,6 +254,12 @@
       "description": "Options to fine tune all variants that are reported by the workflow, using the 'freebayes' option.",
       "default": "",
       "properties": {
+        "var_filters.min_ao": {
+          "type": "integer",
+          "description": "Minimum number of variant-supporting reads.",
+          "help_text": "Default: 10 ",
+          "default": 10
+        },
         "var_filters.min_dpq": {
           "type": "integer",
           "description": "Minimum positional depth after Q filtering.",

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -92,6 +92,42 @@ process FindVariants{
         """
 }
 
+// process FilterValidateVariants{
+//     publishDir "${params.output_dir}/variants", mode: 'copy'
+//     label 'many_low_cpu_high_mem'
+
+//     input:
+//         tuple path(snp_vcf), path(indel_vcf), val(X), path(perbase_table)
+
+//     output:
+//         tuple path("${snp_vcf.simpleName}_filtered.snp.vcf"), path("${snp_vcf.simpleName}_filtered.indel.vcf")
+    
+//     script:
+//         """
+//         vcf_filter_validate.py -i $snp_vcf -o ${snp_vcf.simpleName}_filtered.snp.vcf \
+//         -p $perbase_table \
+//         --min_dir_ratio $params.snp_filters.min_dir_ratio \
+//         --min_dir_count $params.snp_filters.min_dir_count \
+//         --min_dpq $params.snp_filters.min_dpq \
+//         --min_dpq_n $params.snp_filters.min_dpq_n \
+//         --min_dpq_ratio $params.snp_filters.min_dpq_ratio \
+//         --min_vaf $params.snp_filters.min_vaf \
+//         --min_rel_ratio $params.snp_filters.min_rel_ratio \
+//         --min_abq $params.snp_filters.min_abq
+
+//        vcf_filter_validate.py -i $indel_vcf -o ${indel_vcf.simpleName}_filtered.indel.vcf \
+//        -p $perbase_table \
+//         --min_dir_ratio $params.indel_filters.min_dir_ratio \
+//         --min_dir_count $params.indel_filters.min_dir_count \
+//         --min_dpq $params.indel_filters.min_dpq \
+//         --min_dpq_n $params.indel_filters.min_dpq_n \
+//         --min_dpq_ratio $params.indel_filters.min_dpq_ratio \
+//         --min_vaf $params.indel_filters.min_vaf \
+//         --min_rel_ratio $params.indel_filters.min_rel_ratio \
+//         --min_abq $params.indel_filters.min_abq
+//         """
+// }
+
 process FilterValidateVariants{
     publishDir "${params.output_dir}/variants", mode: 'copy'
     label 'many_low_cpu_high_mem'
@@ -104,27 +140,25 @@ process FilterValidateVariants{
     
     script:
         """
-        vcf_filter_validate.py -i $snp_vcf -o ${snp_vcf.simpleName}_filtered.snp.vcf \
-        -p $perbase_table \
-        --min_dir_ratio $params.snp_filters.min_dir_ratio \
-        --min_dir_count $params.snp_filters.min_dir_count \
+        vcf_filter_freebayes.py -i $snp_vcf -o ${snp_vcf.simpleName}_filtered.snp.vcf \
+        --perbase_table $perbase_table \
+        --dynamic_vaf_params $params.dynamic_vaf_params_file \
         --min_dpq $params.snp_filters.min_dpq \
         --min_dpq_n $params.snp_filters.min_dpq_n \
         --min_dpq_ratio $params.snp_filters.min_dpq_ratio \
-        --min_vaf $params.snp_filters.min_vaf \
+        --max_sap 0 \
         --min_rel_ratio $params.snp_filters.min_rel_ratio \
         --min_abq $params.snp_filters.min_abq
 
-       vcf_filter_validate.py -i $indel_vcf -o ${indel_vcf.simpleName}_filtered.indel.vcf \
-       -p $perbase_table \
-        --min_dir_ratio $params.indel_filters.min_dir_ratio \
-        --min_dir_count $params.indel_filters.min_dir_count \
+        vcf_filter_freebayes.py -i $indel_vcf -o ${indel_vcf.simpleName}_filtered.indel.vcf \
+        --perbase_table $perbase_table \
+        --dynamic_vaf_params $params.dynamic_vaf_params_file \
         --min_dpq $params.indel_filters.min_dpq \
         --min_dpq_n $params.indel_filters.min_dpq_n \
         --min_dpq_ratio $params.indel_filters.min_dpq_ratio \
-        --min_vaf $params.indel_filters.min_vaf \
+        --max_sap 0 \
         --min_rel_ratio $params.indel_filters.min_rel_ratio \
-        --min_abq $params.indel_filters.min_abq
+        --min_abq $params.indel_filters.min_abq   
         """
 }
 


### PR DESCRIPTION
- activate dynamic variant filtering for vc `validate`
- ammended how the AO tag is written in vc `validate`: in accordance with freebayes, the tag stands for the sum of qualities of the alternative allele
- ammended user options in epi2me interface