### PR TITLE
Catch bcftools concat errors and atomize VCF parsing processes

### DIFF
--- a/bin/annotate_vcf.py
+++ b/bin/annotate_vcf.py
@@ -11,6 +11,7 @@ import requests
 
 class NoColocatedVariantsException(Exception):
     "Raised when an Ensembl-VEP query does not return any colocated variants."
+
     pass
 
 
@@ -151,8 +152,10 @@ class VCF_file:
             )
             json_data = json.loads(response.text)[0]
 
-        except KeyError:
+        except (KeyError, ConnectionError) as error:
             # No response data found in this query location
+            # or connection was aborted
+            print(error)
             return
 
         return json_data

--- a/main.nf
+++ b/main.nf
@@ -135,8 +135,8 @@ include {
 include {
     ProcessTargetRegions
     CallVariantsFreebayes
-    Mutect2
-    ValidatePosibleVariantLocations
+    CallVariantsMutect2
+    CallVariantsValidate
 } from "./subworkflows/variant_calling"
 
 // include {
@@ -288,13 +288,13 @@ workflow {
     variant_vcf = ""
 
     if (params.variant_calling == "validate") {
-        ValidatePosibleVariantLocations(
+        CallVariantsValidate(
             reads_aligned_filtered,
             regions,
             PrepareGenome.out.fasta_combi
         )
-        locations = ValidatePosibleVariantLocations.out.locations
-        variant_vcf = ValidatePosibleVariantLocations.out.variants
+        locations = CallVariantsValidate.out.locations
+        variant_vcf = CallVariantsValidate.out.variants
     }
     else if (params.variant_calling == "freebayes") {
         CallVariantsFreebayes(

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -98,12 +98,12 @@ process FilterValidateVariants{
         val(mode)
 
     output:
-        tuple path("${snp_vcf.simpleName}_filtered.snp.vcf"), path("${indel_vcf.simpleName}_filtered.indel.vcf")
+        tuple path("${vcf.simpleName}_filtered.vcf")
     
     script:
-        // Conditional params???
+    if ( mode == 'snp' )
         """
-        vcf_filter.py -i $snp_vcf -o ${snp_vcf.simpleName}_filtered.snp.vcf \
+        vcf_filter.py -i $snp_vcf -o ${vcf.simpleName}_filtered.vcf \
         --perbase_table $perbase_table \
         --dynamic_vaf_params $params.dynamic_vaf_params_file \
         --min_ao $params.snp_filters.min_ao \
@@ -115,7 +115,9 @@ process FilterValidateVariants{
         --min_abq $params.snp_filters.min_abq
         """
 
-        vcf_filter.py -i $indel_vcf -o ${indel_vcf.simpleName}_filtered.indel.vcf \
+    else if ( mode == 'indel' )
+        """
+        vcf_filter.py -i $indel_vcf -o ${vcf.simpleName}_filtered.vcf \
         --perbase_table $perbase_table \
         --dynamic_vaf_params $params.dynamic_vaf_params_file \
         --min_ao $params.indel_filters.min_ao \
@@ -147,10 +149,6 @@ process SortVCF{
         bgzip -f ${vcf.simpleName}_sorted.vcf
         tabix -f ${vcf.simpleName}_sorted.vcf.gz
         """
-}
-
-    rm -r tmpdir
-    """
 }
 
 

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -167,7 +167,12 @@ process MergeVCF{
     if ( mode == 'noisy' )
         """
         bcftools concat -a ${snp_vcf.simpleName}.vcf.gz ${indel_vcf.simpleName}.vcf.gz \
-        -O v -o ${X}_${mode}.tmp.vcf
+        -O v -o ${X}_${mode}.tmp.vcf \
+        2> >(tee -a error.txt >&2) && \
+        if grep -q "E::" error.txt; then \
+        echo "VCF concatenation failed in certain rows.\n"; \
+        exit 1; \
+        fi
 
         bcftools sort ${X}_${mode}.tmp.vcf -o ${X}_${mode}.vcf --temp-dir .
         rm ${X}_${mode}.tmp.vcf
@@ -176,7 +181,12 @@ process MergeVCF{
     else if ( mode == 'filtered' )
         """
         bcftools concat -a ${snp_vcf.simpleName}.vcf.gz ${indel_vcf.simpleName}.vcf.gz \
-        -O v -o ${X}_${mode}.tmp.vcf
+        -O v -o ${X}_${mode}.tmp.vcf \
+        2> >(tee -a error.txt >&2) && \
+        if grep -q "E::" error.txt; then \
+        echo "VCF concatenation failed in certain rows.\n"; \
+        exit 1; \
+        fi
 
         bcftools sort ${X}_${mode}.tmp.vcf -o ${X}_${mode}.vcf --temp-dir .
         rm ${X}_${mode}.tmp.vcf

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -76,7 +76,7 @@ process FindVariants{
         tuple val(X), path(validation_bed)
 
     output:
-        tuple path("${bam.simpleName}.snp.vcf"), path("${bam.simpleName}.indel.vcf")
+        tuple val(X), path("${bam.simpleName}_snp.vcf"), path("${bam.simpleName}_indel.vcf")
     
     script:
         // We sleep and access the reference genome, since in some rare cases the file needs accessing to 
@@ -85,7 +85,7 @@ process FindVariants{
         sleep 1
         ls
         head $reference_genome
-        determine_vaf.py $reference_genome $validation_bed $bam ${bam.simpleName}.snp.vcf ${bam.simpleName}.indel.vcf --threads ${task.cpus} 
+        determine_vaf.py $reference_genome $validation_bed $bam ${bam.simpleName}_snp.vcf ${bam.simpleName}_indel.vcf --threads ${task.cpus} 
         """
 }
 
@@ -94,14 +94,16 @@ process FilterValidateVariants{
     label 'many_low_cpu_high_mem'
 
     input:
-        tuple path(snp_vcf), path(indel_vcf), val(X), path(perbase_table)
+        tuple val(X), path(vcf), path(perbase_table)
+        val(mode)
 
     output:
-        tuple path("${snp_vcf.simpleName}.filtered.snp.vcf"), path("${indel_vcf.simpleName}.filtered.indel.vcf")
+        tuple path("${snp_vcf.simpleName}_filtered.snp.vcf"), path("${indel_vcf.simpleName}_filtered.indel.vcf")
     
     script:
+        // Conditional params???
         """
-        vcf_filter.py -i $snp_vcf -o ${snp_vcf.simpleName}.filtered.snp.vcf \
+        vcf_filter.py -i $snp_vcf -o ${snp_vcf.simpleName}_filtered.snp.vcf \
         --perbase_table $perbase_table \
         --dynamic_vaf_params $params.dynamic_vaf_params_file \
         --min_ao $params.snp_filters.min_ao \
@@ -111,8 +113,9 @@ process FilterValidateVariants{
         --max_sap 0 \
         --min_rel_ratio $params.snp_filters.min_rel_ratio \
         --min_abq $params.snp_filters.min_abq
+        """
 
-        vcf_filter.py -i $indel_vcf -o ${indel_vcf.simpleName}.filtered.indel.vcf \
+        vcf_filter.py -i $indel_vcf -o ${indel_vcf.simpleName}_filtered.indel.vcf \
         --perbase_table $perbase_table \
         --dynamic_vaf_params $params.dynamic_vaf_params_file \
         --min_ao $params.indel_filters.min_ao \
@@ -123,84 +126,83 @@ process FilterValidateVariants{
         --min_rel_ratio $params.indel_filters.min_rel_ratio \
         --min_abq $params.indel_filters.min_abq   
         """
+
+    else
+        error "Invalid merging mode (VCF type): ${mode}. Valid modes are 'snp' or 'indel'."
 }
 
-process MergeNoisyVCF{
+process SortVCF{
+    // publishDir "${params.output_dir}/variants", mode: 'copy'
+    label 'many_low_cpu_high_mem'
+
+    input:
+        tuple val(X), path(vcf)
+
+    output:
+        tuple val(X), path("${vcf.simpleName}_sorted.vcf.gz"), path("${vcf.simpleName}_sorted.vcf.gz.tbi")
+    
+    script:
+        """
+        bcftools sort $vcf -o ${vcf.simpleName}_sorted.vcf --temp-dir .
+        bgzip -f ${vcf.simpleName}_sorted.vcf
+        tabix -f ${vcf.simpleName}_sorted.vcf.gz
+        """
+}
+
+    rm -r tmpdir
+    """
+}
+
+
+process MergeVCF{
     publishDir "${params.output_dir}/variants", mode: 'copy'
     label 'many_low_cpu_high_mem'
 
     input:
-        tuple path(noisy_snp_vcf), path(noisy_indel_vcf)
+        tuple val(X), path(snp_vcf), path(snp_tbi), path(indel_vcf), path(indel_tbi)
+        val(mode)
 
     output:
-        path("${noisy_snp_vcf.simpleName}.vcf")
+        tuple val(X), path("${X}_${mode}.vcf")
     
     script:
+    if ( mode == 'noisy' )
         """
-	    mkdir tmpdir
+        bcftools concat -a ${snp_vcf.simpleName}.vcf.gz ${indel_vcf.simpleName}.vcf.gz \
+        -O v -o ${X}_${mode}.tmp.vcf
 
-        bcftools sort $noisy_snp_vcf -o ${noisy_snp_vcf.simpleName}.sorted.snp.vcf --temp-dir tmpdir
-        bgzip ${noisy_snp_vcf.simpleName}.sorted.snp.vcf
-        tabix ${noisy_snp_vcf.simpleName}.sorted.snp.vcf.gz
-
-        bcftools sort $noisy_indel_vcf -o ${noisy_indel_vcf.simpleName}.sorted.indel.vcf --temp-dir tmpdir
-        bgzip ${noisy_indel_vcf.simpleName}.sorted.indel.vcf
-        tabix ${noisy_indel_vcf.simpleName}.sorted.indel.vcf.gz
-
-        bcftools concat -a ${noisy_snp_vcf.simpleName}.sorted.snp.vcf.gz ${noisy_indel_vcf.simpleName}.sorted.indel.vcf.gz \
-        -O v -o ${noisy_snp_vcf.simpleName}.tmp.vcf
-        bcftools sort ${noisy_snp_vcf.simpleName}.tmp.vcf -o ${noisy_snp_vcf.simpleName}.vcf --temp-dir tmpdir
-        rm ${noisy_snp_vcf.simpleName}.tmp.vcf
-
-	    rm -r tmpdir
+        bcftools sort ${X}_${mode}.tmp.vcf -o ${X}_${mode}.vcf --temp-dir .
+        rm ${X}_${mode}.tmp.vcf
         """
+
+    else if ( mode == 'filtered' )
+        """
+        bcftools concat -a ${snp_vcf.simpleName}.vcf.gz ${indel_vcf.simpleName}.vcf.gz \
+        -O v -o ${X}_${mode}.tmp.vcf
+
+        bcftools sort ${X}_${mode}.tmp.vcf -o ${X}_${mode}.vcf --temp-dir .
+        rm ${X}_${mode}.tmp.vcf
+        """
+
+    else
+        error "Invalid merging mode (VCF type): ${mode}. Valid modes are 'noisy' or 'filtered'."
 }
 
-process MergeFilteredVCF{
-    publishDir "${params.output_dir}/variants", mode: 'copy'
-    label 'many_low_cpu_high_mem'
-
-    input:
-        tuple path(filtered_snp_vcf), path(filtered_indel_vcf)
-
-    output:
-        path("${filtered_snp_vcf.simpleName}_filtered.vcf")
-    
-    script:
-        """
-	    mkdir tmpdir
-
-        bcftools sort $filtered_snp_vcf -o ${filtered_snp_vcf.simpleName}_filtered.sorted.snp.vcf --temp-dir tmpdir
-        bgzip ${filtered_snp_vcf.simpleName}_filtered.sorted.snp.vcf
-        tabix ${filtered_snp_vcf.simpleName}_filtered.sorted.snp.vcf.gz
-
-        bcftools sort $filtered_indel_vcf -o ${filtered_indel_vcf.simpleName}_filtered.sorted.indel.vcf --temp-dir tmpdir
-        bgzip ${filtered_indel_vcf.simpleName}_filtered.sorted.indel.vcf
-        tabix ${filtered_indel_vcf.simpleName}_filtered.sorted.indel.vcf.gz
-
-        bcftools concat -a ${filtered_snp_vcf.simpleName}_filtered.sorted.snp.vcf.gz ${filtered_indel_vcf.simpleName}_filtered.sorted.indel.vcf.gz \
-        -O v -o ${filtered_snp_vcf.simpleName}_filtered.tmp.vcf
-        bcftools sort ${filtered_snp_vcf.simpleName}_filtered.tmp.vcf -o ${filtered_snp_vcf.simpleName}_filtered.vcf --temp-dir tmpdir
-        rm ${filtered_snp_vcf.simpleName}_filtered.tmp.vcf
-
-	    rm -r tmpdir
-        """
-}
 
 process AnnotateVCF{
     publishDir "${params.output_dir}/variants", mode: 'copy'
     label 'many_low_cpu_high_mem'
 
     input:
-        path(variant_vcf)
+        tuple val(X), path(vcf)
 
 
     output:
-        path("${variant_vcf.simpleName}_annotated.vcf")
+        tuple val(X), path("${vcf.simpleName}_annotated.vcf")
     
     script:
         """
-        annotate_vcf.py $variant_vcf ${variant_vcf.simpleName}_annotated.vcf
+        annotate_vcf.py $vcf ${vcf.simpleName}_annotated.vcf
         """
 }
 

--- a/subworkflows/modules/bin.nf
+++ b/subworkflows/modules/bin.nf
@@ -98,12 +98,12 @@ process FilterValidateVariants{
         val(mode)
 
     output:
-        tuple path("${vcf.simpleName}_filtered.vcf")
+        tuple val(X), path("${vcf.simpleName}_filtered.vcf")
     
     script:
     if ( mode == 'snp' )
         """
-        vcf_filter.py -i $snp_vcf -o ${vcf.simpleName}_filtered.vcf \
+        vcf_filter.py -i $vcf -o ${vcf.simpleName}_filtered.vcf \
         --perbase_table $perbase_table \
         --dynamic_vaf_params $params.dynamic_vaf_params_file \
         --min_ao $params.snp_filters.min_ao \
@@ -117,7 +117,7 @@ process FilterValidateVariants{
 
     else if ( mode == 'indel' )
         """
-        vcf_filter.py -i $indel_vcf -o ${vcf.simpleName}_filtered.vcf \
+        vcf_filter.py -i $vcf -o ${vcf.simpleName}_filtered.vcf \
         --perbase_table $perbase_table \
         --dynamic_vaf_params $params.dynamic_vaf_params_file \
         --min_ao $params.indel_filters.min_ao \


### PR DESCRIPTION
To make it easier to test, especially bcftools behavior around `bcftools concat` and `bcftools sort`