### PR TITLE
Release v0.12.1

### DIFF
--- a/bin/determine_vaf.py
+++ b/bin/determine_vaf.py
@@ -196,7 +196,7 @@ def main(
 if __name__ == "__main__":
     import argparse
 
-    dev = True
+    dev = False
     if not dev:
         parser = argparse.ArgumentParser(description="")
 

--- a/bin/variant_calling/detect_snp.py
+++ b/bin/variant_calling/detect_snp.py
@@ -149,7 +149,7 @@ def extract_snp_evidence(
             data_present = 0
             non_ref_ratio_filtered = 1
 
-        if len(counts_mc) == 1:
+        if len(counts_mc) == 1 and counts_mc[0][0] == ref_nt:
             # perfect positions
             alleles = (ref_nt, ".")
             alt_base_mean_qual = 0
@@ -179,28 +179,28 @@ def extract_snp_evidence(
                 obs_ratio = 0
 
         # Check support fwd
-        if len(counts_fwd_mc) > 1:
-            counts_fwd_alt = [t for t in counts_fwd_mc if t[0] != ref_nt]
-            alt_base_fwd = counts_fwd_alt[0][0]
-            fwd_count = counts_fwd_alt[0][1]
-            alt_base_ratio_fwd = fwd_count / counted_nucs_fwd
+        alt_base_fwd = None
+        fwd_count = 0
+        alt_base_ratio_fwd = 0
 
-        else:
-            alt_base_fwd = None
-            fwd_count = 0
-            alt_base_ratio_fwd = 0
+        if len(counts_fwd_mc) >= 1:
+            counts_fwd_alt = [t for t in counts_fwd_mc if t[0] != ref_nt]
+            if len(counts_fwd_alt) > 0:
+                alt_base_fwd = counts_fwd_alt[0][0]
+                fwd_count = counts_fwd_alt[0][1]
+                alt_base_ratio_fwd = fwd_count / counted_nucs_fwd
 
         # Check support reverse
-        if len(counts_rev_mc) > 1:
-            counts_rev_alt = [t for t in counts_rev_mc if t[0] != ref_nt]
-            alt_base_rev = counts_rev_alt[0][0]
-            rev_count = counts_rev_alt[0][1]
-            alt_base_ratio_rev = rev_count / counted_nucs_rev
+        alt_base_rev = None
+        rev_count = 0
+        alt_base_ratio_rev = 0
 
-        else:
-            alt_base_rev = None
-            rev_count = 0
-            alt_base_ratio_rev = 0
+        if len(counts_rev_mc) >= 1:
+            counts_rev_alt = [t for t in counts_rev_mc if t[0] != ref_nt]
+            if len(counts_rev_alt) > 0:
+                alt_base_rev = counts_rev_alt[0][0]
+                rev_count = counts_rev_alt[0][1]
+                alt_base_ratio_rev = rev_count / counted_nucs_rev
 
         base = None
         if alt_base_fwd == alt_base_rev and alt_base_fwd:
@@ -255,7 +255,7 @@ def main(
     import time
 
     from tqdm import tqdm
-    from vcf_tools import create_bed_positions, initialize_output_vcf, write_vcf_entry
+    from vcf_tools import create_bed_positions, initialize_output_vcf
 
     # logging.debug("started main")
     # Open input files and create empty output VCF

--- a/subworkflows/modules/cycas.nf
+++ b/subworkflows/modules/cycas.nf
@@ -4,7 +4,7 @@ nextflow.enable.dsl=2
 process Cycas{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
     publishDir "${params.output_dir}/consensus", mode: 'copy'
-    label 'many_low_cpu_tiny_mem'
+    label 'many_cpu_medium'
 
     input:
         tuple val(X), path(bam), path(bai)
@@ -23,7 +23,7 @@ process Cycas{
 process CycasSplit{
     // publishDir "${params.output_dir}/${task.process.replaceAll(':', '/')}", pattern: "", mode: 'copy'
     container 'damicyclomics/cycas:0.2.2-rc5'
-    label 'many_low_cpu_low_mem'
+    label 'many_cpu_medium'
 
     input:
         tuple val(X), path(bam), path(bai)


### PR DESCRIPTION
- Fix an issue where the reference nucleotide couldn't be read due to pysam.FastaFile locking the file, reference nucleotide appeared as '.' instead
- Fix an issue where an alternative allele supported by all reads was not counted, because the total number of observed alleles was not > 1, either overall or in a single read direction