### PR TITLE
Fix: VCF entry INFO column missing

### DIFF
--- a/bin/determine_vaf.py
+++ b/bin/determine_vaf.py
@@ -3,21 +3,23 @@ import logging
 import time
 from concurrent.futures import ALL_COMPLETED, ProcessPoolExecutor, wait
 from pathlib import Path
-from threading import Lock
 from typing import Dict
 
 import pysam
 from variant_calling.detect_indel import extract_indel_evidence
 from variant_calling.detect_snp import extract_snp_evidence
-from variant_calling.vcf_tools import (create_bed_lines, initialize_output_vcf,
-                                       write_vcf_entry)
+from variant_calling.vcf_tools import (
+    create_bed_lines,
+    initialize_output_vcf,
+    write_vcf_entry,
+)
 
 
 def process_pileup_column(
     contig: str,
     pos: int,
     bam: str,
-    reference_mapper: Dict[int,str],
+    reference_mapper: Dict[int, str],
     amplicon_edge: bool = False,
     pileup_depth: int = 1_000_000,
     minimum_base_quality: int = 10,
@@ -35,10 +37,10 @@ def process_pileup_column(
         minimum_base_quality: minimum base quality at a given position in a read to be considered, integer.
     """
     logging.debug(f"process column {contig} | {pos}")
-    
+
     # obtain the base for the snp
     ref_nuc = reference_mapper[pos]
-    
+
     # create enteties for when no forloop event happens
     iteration = 0
     snv_evidence = None
@@ -78,7 +80,7 @@ def process_pileup_column(
         return (contig, pos, snv_evidence, indel_evidence)
 
 
-def create_ref_mapper(reference_fasta, contig,start,stop)-> Dict[int,str]:
+def create_ref_mapper(reference_fasta, contig, start, stop) -> Dict[int, str]:
     """
     Code to create a dict with pos -> base for a given contig.
     """
@@ -92,12 +94,10 @@ def create_ref_mapper(reference_fasta, contig,start,stop)-> Dict[int,str]:
             raise OSError(f"Reference genome {reference_fasta} could not be read.")
 
     ref_mapper = {}
-    for pos in range(start,stop+1):
-        ref_nuc = str(
-                reference.fetch(reference=contig, start=pos, end=pos + 1)
-            ).upper()
+    for pos in range(start, stop + 1):
+        ref_nuc = str(reference.fetch(reference=contig, start=pos, end=pos + 1)).upper()
         ref_mapper[pos] = ref_nuc
-    
+
     return ref_mapper
 
 
@@ -135,7 +135,9 @@ def main(
             contig = bed_file_line[0]
             contig_region_start = int(bed_file_line[1])
             contig_region_stop = int(bed_file_line[2])
-            contig_reference_mapper = create_ref_mapper(fasta, contig, contig_region_start, contig_region_stop)
+            contig_reference_mapper = create_ref_mapper(
+                fasta, contig, contig_region_start, contig_region_stop
+            )
             for pos in range(contig_region_start, contig_region_stop):
                 amplicon_edge = (
                     # amplicon start edge
@@ -190,7 +192,9 @@ def main(
     time.sleep(delay_for_pysam_variantfile)
     snp_vcf.close()
     indel_vcf.close()
-    logging.info(f"done, results are in :\n SNP: {snp_output_path}\n INDEL: {indel_output_path}")
+    logging.info(
+        f"done, results are in :\n SNP: {snp_output_path}\n INDEL: {indel_output_path}"
+    )
 
 
 if __name__ == "__main__":
@@ -212,15 +216,9 @@ if __name__ == "__main__":
         main(args.fasta, args.bed, args.bam, args.snp_vcf_out, args.indel_vcf_out)
 
     if dev:
-        fasta = Path(
-            "/home/dami/Software/cyclomicsseq/dev_files/chm13v2_BBCS.fasta"
-        )
-        bed = Path(
-            "/home/dami/Software/cyclomicsseq/dev_files/fastq_roi.bed"
-        )
-        bam = Path(
-            "/home/dami/Software/cyclomicsseq/dev_files/fastq.YM_gt_3.bam"
-        )
+        fasta = Path("/scratch/projects/ROD/ROD_0808_bug/GRCh38_noalt_as_BBCS.fasta")
+        bed = Path("/scratch/projects/ROD/ROD_0808_bug/PAY92969_roi.bed")
+        bam = Path("/scratch/projects/ROD/ROD_0808_bug/PAY92969.YM_gt_3.bam")
         snp_vcf_out = Path("./test_snp.vcf")
         indel_vcf_out = Path("./test_indel.vcf")
 

--- a/bin/variant_calling/detect_snp.py
+++ b/bin/variant_calling/detect_snp.py
@@ -34,7 +34,14 @@ def extract_snp_evidence(
 
     vcf_entry = VCF_entry()
     alleles = (ref_nt, ".")
-    info = "."
+    info = {
+        "TYPE": "snp",
+        "DP": vcf_entry.DP,
+        "QA": vcf_entry.ABQ * vcf_entry.TOTC,
+        "AO": vcf_entry.TOTC,
+        "SAF": vcf_entry.FWDC,
+        "SAR": vcf_entry.REVC,
+    }
 
     total = 0
     counted_nucs = 0
@@ -138,7 +145,16 @@ def extract_snp_evidence(
 
     # empty position:
     if counted_nucs == 0 or total == 0:
-        return (assembly, alleles, vcf_entry)
+        info = {
+            "TYPE": "snp",
+            "DP": total,
+            "QA": alt_base_mean_qual * tot_count,
+            "AO": tot_count,
+            "SAF": fwd_count,
+            "SAR": rev_count,
+        }
+
+        return (assembly, alleles, vcf_entry, info)
 
     else:
         counts_ref = [t for t in counts_mc if t[0] == ref_nt]


### PR DESCRIPTION
- Add default INFO column to all SNP and Indel VCF entries
- Update INFO column on 0 SNP counts before returning VCF entry object