### PR TITLE
Fix: EnsemblVEP parsing issues, missing info in VCF entries, timeline and report overwriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # changelog
 
+## 0.12.2
+
+- Enable overwriting of nextflow timeline and report
+- Hotfix for missing info tab in VCF entries for SNPs in ends of amplicons with some read depth but zero alternative nucleotide counts
+- Hotfix for EnsemblVEP API responses that caused a JSON decoding error
+
 ## 0.12.1
 
 - Fix an issue where the reference nucleotide couldn't be read due to pysam.FastaFile locking the file, reference nucleotide appeared as '.' instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.12.1
+
+- Fix an issue where the reference nucleotide couldn't be read due to pysam.FastaFile locking the file, reference nucleotide appeared as '.' instead
+- Fix an issue where an alternative allele supported by all reads was not counted, because the total number of observed alleles was not > 1, either overall or in a single read direction
+
 ## 0.12.0
 
 - Contaminant detection module

--- a/bin/annotate_vcf.py
+++ b/bin/annotate_vcf.py
@@ -152,7 +152,7 @@ class VCF_file:
             )
             json_data = json.loads(response.text)[0]
 
-        except (KeyError, ConnectionError) as error:
+        except (KeyError, ConnectionError, json.decoder.JSONDecodeError) as error:
             # No response data found in this query location
             # or connection was aborted
             print(error)

--- a/bin/determine_vaf.py
+++ b/bin/determine_vaf.py
@@ -40,7 +40,6 @@ def process_pileup_column(
 
     # obtain the base for the snp
     ref_nuc = reference_mapper[pos]
-
     # create enteties for when no forloop event happens
     iteration = 0
     snv_evidence = None
@@ -97,7 +96,7 @@ def create_ref_mapper(reference_fasta, contig, start, stop) -> Dict[int, str]:
     for pos in range(start, stop + 1):
         ref_nuc = str(reference.fetch(reference=contig, start=pos, end=pos + 1)).upper()
         ref_mapper[pos] = ref_nuc
-
+        
     return ref_mapper
 
 
@@ -216,9 +215,15 @@ if __name__ == "__main__":
         main(args.fasta, args.bed, args.bam, args.snp_vcf_out, args.indel_vcf_out)
 
     if dev:
-        fasta = Path("/scratch/projects/ROD/ROD_0808_bug/GRCh38_noalt_as_BBCS.fasta")
-        bed = Path("/scratch/projects/ROD/ROD_0808_bug/PAY92969_roi.bed")
-        bam = Path("/scratch/projects/ROD/ROD_0808_bug/PAY92969.YM_gt_3.bam")
+        fasta = Path(
+            "/home/dami/Software/cyclomicsseq/dev_files/chm13v2_BBCS.fasta"
+        )
+        bed = Path(
+            "/home/dami/Software/cyclomicsseq/dev_files/fastq_roi.bed"
+        )
+        bam = Path(
+            "/home/dami/Software/cyclomicsseq/dev_files/fastq.YM_gt_3.bam"
+        )
         snp_vcf_out = Path("./test_snp.vcf")
         indel_vcf_out = Path("./test_indel.vcf")
 

--- a/bin/variant_calling/detect_indel.py
+++ b/bin/variant_calling/detect_indel.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import re
+import time
 from collections import Counter
 from dataclasses import dataclass, field, fields
 from pathlib import Path
@@ -7,7 +8,7 @@ from typing import Dict, Tuple
 
 import numpy as np
 import pysam
-from variant_calling.vcf_tools import VCF_entry
+from variant_calling.vcf_tools import VCF_entry, create_bed_lines, create_ref_mapper
 
 
 @dataclass
@@ -203,6 +204,7 @@ def extract_indel_evidence(
     ref_nt: str,
     reference_mapper: Dict[int, str],
     pos: int,
+    amplicon_end: int,
     high_base_quality_cutoff: int = 80,
     edge_of_amplicon: bool = False,
 ) -> Tuple[str, Tuple[str, str], VCF_entry]:
@@ -240,13 +242,16 @@ def extract_indel_evidence(
         indel = check_indel(pileupcolumn)
         if indel.found:
             if indel.type == "del":
-                # Adjust reference allele to include deleted seq
-                ref_seq = [
-                    reference_mapper[x].upper()
-                    for x in range(pos, pos + indel.length + 1)
-                ]
-                ref_seq = "".join(ref_seq)
-                alleles = (str(ref_seq).upper(), str(ref_seq[0]).upper())
+                if pos + indel.length + 1 <= amplicon_end:
+                    # Adjust reference allele to include deleted seq
+                    ref_seq = [
+                        reference_mapper[x].upper()
+                        for x in range(pos, pos + indel.length + 1)
+                    ]
+                    ref_seq = "".join(ref_seq)
+                    alleles = (str(ref_seq).upper(), str(ref_seq[0]).upper())
+                else:
+                    return (assembly, alleles, vcf_entry, info)
             else:
                 alleles = (ref_nt, ref_nt + indel.variant_nucleotide)
 
@@ -324,10 +329,7 @@ def main(
         pileup_depth: Maximum pileup depth, integer (DEFAULT=1_000_000).
     """
 
-    import time
-
-    from tqdm import tqdm
-    from vcf_tools import create_bed_positions, initialize_output_vcf
+    from vcf_tools import initialize_output_vcf
 
     # logging.debug("started main")
     # Open input files and create empty output VCF
@@ -335,63 +337,76 @@ def main(
     reference = pysam.FastaFile(fasta)
     vcf = initialize_output_vcf(output_path, bam_af.references)
 
-    # Iterate over positions in search space indicated in BED file
-    for contig, pos, amplicon_edge in tqdm(create_bed_positions(bed)):
-        # Check statistics for this position,
-        # potentially finding a new variant
-
-        positional_pileup = bam_af.pileup(
-            contig,
-            pos,
-            pos + 1,
-            truncate=True,
-            max_depth=pileup_depth,
-            min_base_quality=10,
-            stepper="all",
+    for bed_file_line in create_bed_lines(bed):
+        contig = bed_file_line[0]
+        contig_region_start = int(bed_file_line[1])
+        contig_region_stop = int(bed_file_line[2])
+        contig_reference_mapper = create_ref_mapper(
+            fasta, contig, contig_region_start, contig_region_stop
         )
 
-        ref_seq = reference.fetch(reference=contig, start=pos, end=pos + 1)
-
-        for pileupcolumn in positional_pileup:
-            result = extract_indel_evidence(
-                pileupcolumn=pileupcolumn,
-                assembly=contig,
-                ref_nt=str(ref_seq).upper(),
-                reference_fa=fasta,
-                pos=pos,
-                edge_of_amplicon=amplicon_edge,
+        for pos in range(contig_region_start, contig_region_stop):
+            close_to_edge = (
+                # close to start
+                pos - 4 <= int(contig_region_start)
+                or
+                # close to end
+                pos + 4 >= int(contig_region_stop)
             )
 
-            if result[1][0] != ".":
-                # Reference allele is not '.', then a variant was found
-                # The 'start' value is 0-based, 'stop' is 1-based
-                r = vcf.new_record(
-                    contig=contig, start=pos, alleles=result[1], filter="PASS"
+            positional_pileup = bam_af.pileup(
+                contig,
+                pos,
+                pos + 1,
+                truncate=True,
+                max_depth=pileup_depth,
+                min_base_quality=10,
+                stepper="all",
+            )
+
+            ref_seq = reference.fetch(reference=contig, start=pos, end=pos + 1)
+
+            for pileupcolumn in positional_pileup:
+                result = extract_indel_evidence(
+                    pileupcolumn=pileupcolumn,
+                    assembly=contig,
+                    ref_nt=str(ref_seq).upper(),
+                    reference_mapper=contig_reference_mapper,
+                    pos=pos,
+                    edge_of_amplicon=close_to_edge,
+                    amplicon_end=contig_region_stop,
                 )
 
-                # Write found variant as a new entry to VCF output
-                for fld in fields(result[2]):
-                    fld_value = getattr(result[2], fld.name)
-                    if isinstance(fld_value, (float, np.float64, np.float32)):
-                        fld_entry = str(f"{getattr(result[2], fld.name):.6f}")
-                    elif isinstance(fld_value, int):
-                        fld_entry = str(f"{getattr(result[2], fld.name)}")
-                    else:
-                        fld_entry = str(fld_value)
+                if result[1][0] != ".":
+                    # Reference allele is not '.', then a variant was found
+                    # The 'start' value is 0-based, 'stop' is 1-based
+                    r = vcf.new_record(
+                        contig=contig, start=pos, alleles=result[1], filter="PASS"
+                    )
 
-                    r.samples["SAMPLE1"][fld.name] = fld_entry
+                    # Write found variant as a new entry to VCF output
+                    for fld in fields(result[2]):
+                        fld_value = getattr(result[2], fld.name)
+                        if isinstance(fld_value, (float, np.float64, np.float32)):
+                            fld_entry = str(f"{getattr(result[2], fld.name):.6f}")
+                        elif isinstance(fld_value, int):
+                            fld_entry = str(f"{getattr(result[2], fld.name)}")
+                        else:
+                            fld_entry = str(fld_value)
 
-                # Write info tag values to VCF output
-                # These values will be used to filter the VCF
-                for tag_id, value in result[3].items():
-                    r.info[tag_id] = value
+                        r.samples["SAMPLE1"][fld.name] = fld_entry
 
-                vcf.write(r)
+                    # Write info tag values to VCF output
+                    # These values will be used to filter the VCF
+                    for tag_id, value in result[3].items():
+                        r.info[tag_id] = value
 
-            else:
-                # Reference allele is '.', then no variant was found
-                # Don't write anthing to VCF output file
-                continue
+                    vcf.write(r)
+
+                else:
+                    # Reference allele is '.', then no variant was found
+                    # Don't write anthing to VCF output file
+                    continue
 
     time.sleep(0.5)
     vcf.close()

--- a/bin/variant_calling/vcf_tools.py
+++ b/bin/variant_calling/vcf_tools.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import logging
+import time
 from dataclasses import dataclass, fields
+from typing import Dict
 
 import numpy as np
 import pysam
@@ -38,6 +40,27 @@ def is_intable(value):
         return True
     except ValueError:
         return False
+
+
+def create_ref_mapper(reference_fasta, contig, start, stop) -> Dict[int, str]:
+    """
+    Code to create a dict with pos -> base for a given contig.
+    """
+    try:
+        reference = pysam.FastaFile(reference_fasta)
+    except OSError:
+        try:
+            time.sleep(0.2)
+            reference = pysam.FastaFile(reference_fasta)
+        except:
+            raise OSError(f"Reference genome {reference_fasta} could not be read.")
+
+    ref_mapper = {}
+    for pos in range(start, stop + 1):
+        ref_nuc = str(reference.fetch(reference=contig, start=pos, end=pos + 1)).upper()
+        ref_mapper[pos] = ref_nuc
+
+    return ref_mapper
 
 
 def create_bed_lines(bed_file):

--- a/bin/variant_calling/vcf_tools.py
+++ b/bin/variant_calling/vcf_tools.py
@@ -107,16 +107,20 @@ def write_vcf_entry(vcf, contig, pos, vcf_entry):
         vcf_entry: A tuple containing  the contig name, a tuple with reference and
             alternative alleles, and a VCF_entry object with variant annotations to add.
     """
+    pos_alleles = vcf_entry[1]
+    variant_format = vcf_entry[2]
+    variant_info = vcf_entry[3]
+
     r = vcf.new_record(
-        contig=contig, start=pos, stop=pos + 1, alleles=vcf_entry[1], filter="PASS"
+        contig=contig, start=pos, stop=pos + 1, alleles=pos_alleles, filter="PASS"
     )
 
-    for fld in fields(vcf_entry[2]):
-        fld_value = getattr(vcf_entry[2], fld.name)
+    for fld in fields(variant_format):
+        fld_value = getattr(variant_format, fld.name)
         if type(fld_value) in [float, np.float64, np.float32]:
-            fld_entry = str(f"{getattr(vcf_entry[2], fld.name):.6f}")
+            fld_entry = str(f"{getattr(variant_format, fld.name):.6f}")
         elif type(fld_value) == int:
-            fld_entry = str(f"{getattr(vcf_entry[2], fld.name)}")
+            fld_entry = str(f"{getattr(variant_format, fld.name)}")
         else:
             fld_entry = str(fld_value)
 
@@ -124,7 +128,7 @@ def write_vcf_entry(vcf, contig, pos, vcf_entry):
 
     # Write info tag values to VCF output
     # These values will be used to filter the VCF
-    for tag_id, value in vcf_entry[3].items():
+    for tag_id, value in variant_info.items():
         r.info[tag_id] = value
 
     vcf.write(r)

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest{
     description = 'Create high quality alignment data with variant identification for the Cyclomics CyclomicsSeq protocol.'
     mainScript      = 'main.nf'
     nextflowVersion = '>=20.10.0'
-    version         = '0.12.1'
+    version         = '0.12.2'
 }
 
 epi2melabs {

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest{
     description = 'Create high quality alignment data with variant identification for the Cyclomics CyclomicsSeq protocol.'
     mainScript      = 'main.nf'
     nextflowVersion = '>=20.10.0'
-    version         = '0.12.0'
+    version         = '0.12.1'
 }
 
 epi2melabs {

--- a/nextflow.config
+++ b/nextflow.config
@@ -227,3 +227,4 @@ trace {
   overwrite = true
   file = "${params.output_dir}/execution/nextflow_trace.txt"
 }
+cleanup = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -214,10 +214,12 @@ params{
 
 timeline {
   enabled = true
+  overwrite = true
   file = "${params.output_dir}/execution/nextflow_timeline.html"
 }
 report {
   enabled = true
+  overwrite = true
   file = "${params.output_dir}/execution/nextflow_report.html"
 }
 trace {


### PR DESCRIPTION
- Enable overwriting of nextflow timeline and report; cleanup nextflow work directory on successful workflow completion
- Hotfix for missing info tab in VCF entries for SNPs in ends of amplicons with some read depth but zero alternative nucleotide counts
- Hotfix for EnsemblVEP API responses that caused a JSON decoding error
- Small refactoring of variable names associated with variant calling code; make edge of amplicon detection a user argument if `detect_indel.py` is main