### PR TITLE
Add unique ID to each run and upgrade sample IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ this file is located in the repo, the pipeline needs to know where this file is 
 | --read_pattern                 | Regex pattern to look for fastq's in the read directory. | "**.{fq,fastq,fq.gz,fastq.gz}" |
 | --reference                    | Path to the reference genome to use, will ingest all index files in the same directory.| |
 | --region_file                  | Path to the BED file with regions over which to run the analysis of consensus reads. | auto |
-| --sample_id                    | An ID for the sample analysed. If the run is barcoded and the input directory contains many barcode subdirectories, then the barcode names will automatically be taken as sample IDs. | |
+| --sample_id                    | Override automated sample ID detection and use the provided value instead. | |
 | --output_dir                   | Directory path where the results, including intermediate files, are stored. | "$HOME/Data/CyclomicsSeq" |
 | --report                       | Type of report to generate at the end of the pipeline [standard, detailed, skip]. | standard |
 

--- a/main.nf
+++ b/main.nf
@@ -147,7 +147,7 @@ def MinKnow_barcode_folder_pattern = ~/^barcode\d{2}$|unclassified/
 // MinKnow run folder
 def MinKnow_auto_run_folder_pattern = ~/^\d{8}_\d{4}_.+/  // Regular expression for 8 digits, underscore, 4 digits, underscore, and some text
 
-def getValidParent(dir, invalidList, barcodePattern, pattern) {
+def getValidParent(dir, invalidList, barcodePattern, runFolderPattern) {
     def currentDir = dir
     def barcode = ""
 
@@ -155,7 +155,7 @@ def getValidParent(dir, invalidList, barcodePattern, pattern) {
         barcode = currentDir.simpleName
     }
 
-    while ((invalidList.contains(currentDir.simpleName) || currentDir.simpleName ==~ barcodePattern || currentDir.simpleName ==~ pattern) && currentDir.Parent != null) {
+    while ((invalidList.contains(currentDir.simpleName) || currentDir.simpleName ==~ barcodePattern || currentDir.simpleName ==~ runFolderPattern) && currentDir.Parent != null) {
         currentDir = currentDir.Parent
     } 
 

--- a/main.nf
+++ b/main.nf
@@ -86,6 +86,7 @@ log.info """
         backbone_file            : $params.backbone_file
         region_file              : $params.region_file  
         output folder            : $params.output_dir
+        sample_id                : $params.sample_id
         Cmd line                 : $workflow.commandLine
     Method:  
         report                   : $params.report
@@ -140,14 +141,31 @@ include {
 // the sample id's will be barcode03, barcode04 and barcode05
 
 def InvalidParents = ['fastq', 'pass', 'fastq_pass', 'fastq_fail', 'fail', 'home']
+
+// Barcode subfolders
+def MinKnow_barcode_folder_pattern = ~/^barcode\d{2}$|unclassified/
 // MinKnow run folder
 def MinKnow_auto_run_folder_pattern = ~/^\d{8}_\d{4}_.+/  // Regular expression for 8 digits, underscore, 4 digits, underscore, and some text
-def getValidParent(dir, invalidList, pattern) {
+
+def getValidParent(dir, invalidList, barcodePattern, pattern) {
     def currentDir = dir
-    while ((invalidList.contains(currentDir.simpleName) || currentDir.simpleName ==~ pattern) && currentDir.Parent != null) {
+    def barcode = ""
+
+    if (currentDir.simpleName ==~ barcodePattern) {
+        barcode = currentDir.simpleName
+    }
+
+    while ((invalidList.contains(currentDir.simpleName) || currentDir.simpleName ==~ barcodePattern || currentDir.simpleName ==~ pattern) && currentDir.Parent != null) {
         currentDir = currentDir.Parent
     } 
-    return currentDir.simpleName
+
+    return [barcode, currentDir.simpleName]
+}
+
+def generateUid = { String alphabet, int n ->
+  new Random().with {
+    (1..n).collect { alphabet[ nextInt( alphabet.length() ) ] }.join()
+  }
 }
 
 // Used in exclusion of failed reads from the inputs.
@@ -213,21 +231,28 @@ workflow {
     }
     read_fastq.dump(tag: "read_fastq_no_fail")
 
+    // Generate a unique ID for the run
+    def run_UID = generateUid( (('A'..'Z')+('a'..'z')+('0'..'9')).join(), 7 )
+
     // Extract valid sample ID's for eah fastq file
     read_fastq = read_fastq.map { it ->
                 // if parentDir is invalid, take grandParentDir etc. etc.
-                def parentDir = it.Parent
-                def sample_ID = getValidParent(it.Parent, InvalidParents, MinKnow_auto_run_folder_pattern)
-                def file_ID = it.simpleName
-                tuple(sample_ID, file_ID, it)
-            }
-    read_fastq.dump(tag: "read_fastq_sample_tagged")
+                def (barcode, sample_ID) = getValidParent(it.Parent, InvalidParents, MinKnow_barcode_folder_pattern, MinKnow_auto_run_folder_pattern)
 
-    // Overwrite the sample ID's if provided via the cli
-    if (params.sample_id != "") {
-        log.warn("Overwriting sample ID for all fastq files due to cli provided sample ID")
-        read_fastq = read_fastq.map { it -> tuple(params.sample_id, it[1], it[2]) }
-    }
+                // Overwrite the sample ID if provided
+                if (params.sample_id != "") {
+                    sample_ID = params.sample_id.toString()
+                }
+                sample_ID = sample_ID.replaceAll("\\s+", "_")
+                sample_ID = sample_ID + "_" + run_UID
+                if (barcode != "") {
+                    sample_ID = sample_ID + "_" + barcode
+                }
+
+                tuple(sample_ID, it.simpleName, it)
+            }
+
+    read_fastq.dump(tag: "read_fastq_sample_tagged")
     read_fastq.dump(tag: "read_fastq")
 
     // Prepare reference genome, combined with backbone sequence

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -24,6 +24,13 @@
       "description": "Options that define where the workflow will take data from for analysis.",
       "default": "",
       "properties": {
+        "sample_id": {
+          "title": "Sample ID (Optional)",
+          "type": "string",
+          "description": "Override the sample ID used in the pipeline.",
+          "help_text": "This option will override automated sample ID detection and use the provided value instead.",
+          "default": ""
+        },
         "reference": {
           "type": "string",
           "format": "file-path",
@@ -62,13 +69,6 @@
       "description": "Options that alter the behaviour of the pipeline, for advanced users.",
       "default": "",
       "properties": {
-        "sample_id": {
-          "title": "Sample ID",
-          "type": "string",
-          "description": "Overwrite the sample id used in the pipeline, disables smart grouping and barcode detection.",
-          "help_text": "This option is useful when you want to use all the data in the input folder and read_pattern in a single analysis.",
-          "default": ""
-        },
         "filtering.minimum_raw_length": {
           "title": "Minimum raw read length",
           "type": "integer",


### PR DESCRIPTION
- Sample ID is now always detected, even if there are no barcode subfolders
- Sample ID may be overriden by user-provided option `sample_id`
- Sample ID is now provided in EPI2ME tab "Input Options", instead of "Pipeline Options"
- Sample ID help text was adjusted accordingly
- For each run a unique ID is now generated and appended to sample IDs
- Barcodes are appended to sample IDs
- Final output files that don't directly correspond to original fastq input files are now named with the newly constructed sample IDs with unique IDs and barcode IDs (if existent) appended.