### PR TITLE
Fix incorrect pairing of consensus reads with respective metadata

### DIFF
--- a/bin/annotate_vcf.py
+++ b/bin/annotate_vcf.py
@@ -22,7 +22,10 @@ def obtain_legacy_cosmic_id(
     """extract legacy information from the clinicaltables.nlm.nih.gov api."""
 
     query = base_url + cosv_id + "&ef=LegacyMutationID"
-    response = requests.get(url=query, headers={"Content-Type": "application/json"})
+    try:
+        response = requests.get(url=query, headers={"Content-Type": "application/json"})
+    except requests.exceptions.ConnectionError:
+        return "None"
     try:
         id_list = set(json.loads(response.text)[2]["LegacyMutationID"])
     except KeyError:  # LegacyMutationID was not found in

--- a/subworkflows.nf
+++ b/subworkflows.nf
@@ -158,12 +158,12 @@ workflow AlignByID {
         jsons
 
     main:
-        id = reads.map(it -> it[0])
         Minimap2Align(reads, reference_genome)
-        metadata_pairs = Minimap2Align.out.join(jsons).map(it -> tuple(it[0], it[1], it[2], it[4]))
+        metadata_pairs = Minimap2Align.out.combine(jsons, by:[0, 1])
 	    AnnotateBamYTags(metadata_pairs)
         bams = AnnotateBamYTags.out.groupTuple(by: 0).map(it -> tuple(it[0], it[1], it[2]))
-        bam = SamtoolsMergeBams(bams)
+        SamtoolsMergeBams(bams)
+        bam = SamtoolsMergeBams.out
 
     emit:
         bam
@@ -206,10 +206,10 @@ workflow AnnotateBam {
 workflow FilterBam {
     take:
         annotated_bam
-        minimun_repeat_count
+        minimum_repeat_count
 
     main:
-        BamTagFilter(annotated_bam, 'YM', minimun_repeat_count)
+        BamTagFilter(annotated_bam, 'YM', minimum_repeat_count)
         if (params.region_file != 'auto' && params.filter_by_alignment_rate == true) {
             BamAlignmentRateFilter(BamTagFilter.out)
             filtered_bam = BamAlignmentRateFilter.out


### PR DESCRIPTION
- Fixes #50 where number of consensus inserts was incorrectly displayed and processed. Metadata pairs were not being properly combined, i.e. consensus bam files were not combined with metadata jsons according to sample and file IDs.
- Handles spontaneous connection errors when trying to retrieve legacy COSMIC IDs (annotation will be 'None' if a ConnectionError occurs)