### PR TITLE
fix: update container version, combine metadata pairs correctly, handle connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 1.1.1
+
+- Updated Docker container to version 0.9.0, to include Cycas 0.5.2
+
 ## 1.1.0
 
 - Added variant support scatterplots to the output report.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.1.1
 
 - Updated Docker container to version 0.9.0, to include Cycas 0.5.2
+- Fixes metadata pairing with consensus BAM files
+- Handles spontaneous connection errors when requesting cosmic legacy IDs, now leading to 'None' annotations in case of error
 
 ## 1.1.0
 

--- a/bin/annotate_vcf.py
+++ b/bin/annotate_vcf.py
@@ -22,7 +22,10 @@ def obtain_legacy_cosmic_id(
     """extract legacy information from the clinicaltables.nlm.nih.gov api."""
 
     query = base_url + cosv_id + "&ef=LegacyMutationID"
-    response = requests.get(url=query, headers={"Content-Type": "application/json"})
+    try:
+        response = requests.get(url=query, headers={"Content-Type": "application/json"})
+    except requests.exceptions.ConnectionError:
+        return "None"
     try:
         id_list = set(json.loads(response.text)[2]["LegacyMutationID"])
     except KeyError:  # LegacyMutationID was not found in

--- a/create_docker.sh
+++ b/create_docker.sh
@@ -1,4 +1,4 @@
-docker build . -t cyclomics/cyclomicsseq:0.8.2
-docker tag cyclomics/cyclomicsseq:0.8.2 cyclomics/cyclomicsseq:latest
-docker push cyclomics/cyclomicsseq:0.8.2
+docker build . -t cyclomics/cyclomicsseq:0.9.0
+docker tag cyclomics/cyclomicsseq:0.9.0 cyclomics/cyclomicsseq:latest
+docker push cyclomics/cyclomicsseq:0.9.0
 docker push cyclomics/cyclomicsseq:latest

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest{
     description = 'Create high quality alignment data with variant identification for the Cyclomics CyclomicsSeq protocol.'
     mainScript      = 'main.nf'
     nextflowVersion = '>=23.04.2'
-    version         = '1.1.0'
+    version         = '1.1.1'
 }
 
 epi2melabs {
@@ -16,7 +16,7 @@ epi2melabs {
 }
 
 
-default_container = 'cyclomics/cyclomicsseq:0.8.2'
+default_container = 'cyclomics/cyclomicsseq:0.9.0'
 
 params.user_conda_location = "${projectDir}/environment.yml"
 

--- a/subworkflows.nf
+++ b/subworkflows.nf
@@ -158,12 +158,12 @@ workflow AlignByID {
         jsons
 
     main:
-        id = reads.map(it -> it[0])
         Minimap2Align(reads, reference_genome)
-        metadata_pairs = Minimap2Align.out.join(jsons).map(it -> tuple(it[0], it[1], it[2], it[4]))
+        metadata_pairs = Minimap2Align.out.combine(jsons, by:[0, 1])
 	    AnnotateBamYTags(metadata_pairs)
         bams = AnnotateBamYTags.out.groupTuple(by: 0).map(it -> tuple(it[0], it[1], it[2]))
-        bam = SamtoolsMergeBams(bams)
+        SamtoolsMergeBams(bams)
+        bam = SamtoolsMergeBams.out
 
     emit:
         bam
@@ -206,10 +206,10 @@ workflow AnnotateBam {
 workflow FilterBam {
     take:
         annotated_bam
-        minimun_repeat_count
+        minimum_repeat_count
 
     main:
-        BamTagFilter(annotated_bam, 'YM', minimun_repeat_count)
+        BamTagFilter(annotated_bam, 'YM', minimum_repeat_count)
         if (params.region_file != 'auto' && params.filter_by_alignment_rate == true) {
             BamAlignmentRateFilter(BamTagFilter.out)
             filtered_bam = BamAlignmentRateFilter.out


### PR DESCRIPTION
- Updates cyclomicsseq container to 0.9.0, which includes Cycas update to 0.5.2
- Fixes metadata pairing with consensus BAM files (#50)
- Handles spontaneous connection errors when requesting cosmic legacy IDs, now leading to 'None' annotations in case of error